### PR TITLE
iOS: Swift implementation of v3 API client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Critic",
     platforms: [
-        .iOS(.v16)
+        .iOS(.v16),
+        .macOS(.v13)
     ],
     products: [
         .library(

--- a/Sources/Critic/API/CriticAPI.swift
+++ b/Sources/Critic/API/CriticAPI.swift
@@ -1,14 +1,219 @@
 import Foundation
 
 /// Handles communication with the Critic v3 REST API.
-public struct CriticAPI: Sendable {
+public actor CriticAPI {
 
-    /// The base URL for API requests.
+    /// The base URL for API requests (e.g. "https://critic.inventiv.io").
     public let baseURL: URL
 
+    /// The organization API token for POST endpoints.
+    public let apiToken: String
+
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
     /// Creates a new API client.
-    /// - Parameter baseURL: The base URL of the Critic API server.
-    public init(baseURL: URL) {
+    public init(baseURL: URL, apiToken: String, session: URLSession = .shared) {
         self.baseURL = baseURL
+        self.apiToken = apiToken
+        self.session = session
+        self.decoder = JSONDecoder()
+    }
+
+    // MARK: - Ping
+
+    /// Register an app install with the Critic API.
+    public func ping(_ request: PingRequest) async throws -> AppInstall {
+        let url = Endpoints.ping(baseURL: baseURL)
+        let body = try JSONEncoder().encode(request)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = body
+
+        let response: PingResponse = try await perform(urlRequest)
+        return response.appInstall
+    }
+
+    // MARK: - Bug Reports
+
+    /// Create a bug report with optional file attachments.
+    public func createBugReport(
+        report: BugReportInput,
+        appInstallId: String,
+        attachments: [(filename: String, mimeType: String, data: Data)]? = nil,
+        deviceStatus: DeviceStatus? = nil
+    ) async throws -> BugReport {
+        let url = Endpoints.bugReports(baseURL: baseURL)
+
+        var formData = MultipartFormData()
+        formData.addField(name: "api_token", value: apiToken)
+        formData.addField(name: "app_install[id]", value: appInstallId)
+        formData.addField(name: "bug_report[description]", value: report.description)
+
+        if let metadata = report.metadata {
+            if let jsonData = try? JSONSerialization.data(withJSONObject: metadata),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                formData.addField(name: "bug_report[metadata]", value: jsonString)
+            }
+        }
+        if let steps = report.stepsToReproduce {
+            formData.addField(name: "bug_report[steps_to_reproduce]", value: steps)
+        }
+        if let user = report.userIdentifier {
+            formData.addField(name: "bug_report[user_identifier]", value: user)
+        }
+
+        if let attachments {
+            for attachment in attachments {
+                formData.addFile(
+                    name: "bug_report[attachments][]",
+                    filename: attachment.filename,
+                    mimeType: attachment.mimeType,
+                    data: attachment.data
+                )
+            }
+        }
+
+        if let status = deviceStatus {
+            addDeviceStatusFields(to: &formData, status: status)
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue(formData.contentType, forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = formData.build()
+
+        return try await perform(urlRequest)
+    }
+
+    /// List bug reports for an app.
+    public func listBugReports(
+        appApiToken: String,
+        archived: Bool? = nil,
+        deviceId: String? = nil,
+        since: String? = nil
+    ) async throws -> PaginatedResponse<BugReport> {
+        var url = Endpoints.bugReports(baseURL: baseURL)
+        var queryItems = [URLQueryItem(name: "app_api_token", value: appApiToken)]
+
+        if let archived {
+            queryItems.append(URLQueryItem(name: "archived", value: String(archived)))
+        }
+        if let deviceId {
+            queryItems.append(URLQueryItem(name: "device_id", value: deviceId))
+        }
+        if let since {
+            queryItems.append(URLQueryItem(name: "since", value: since))
+        }
+
+        url = url.appending(queryItems: queryItems)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+
+        return try await perform(urlRequest)
+    }
+
+    /// Get a single bug report by ID.
+    public func getBugReport(id: String, appApiToken: String) async throws -> BugReport {
+        var url = Endpoints.bugReport(baseURL: baseURL, id: id)
+        url = url.appending(queryItems: [URLQueryItem(name: "app_api_token", value: appApiToken)])
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+
+        return try await perform(urlRequest)
+    }
+
+    // MARK: - Devices
+
+    /// List devices for an app.
+    public func listDevices(appApiToken: String) async throws -> PaginatedResponse<Device> {
+        var url = Endpoints.devices(baseURL: baseURL)
+        url = url.appending(queryItems: [URLQueryItem(name: "app_api_token", value: appApiToken)])
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+
+        return try await perform(urlRequest)
+    }
+
+    // MARK: - Private
+
+    private func perform<T: Decodable & Sendable>(_ request: URLRequest) async throws -> T {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw CriticError.networkError(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CriticError.networkError("Invalid response")
+        }
+
+        try mapHTTPError(statusCode: httpResponse.statusCode, data: data)
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw CriticError.decodingFailed
+        }
+    }
+
+    private func mapHTTPError(statusCode: Int, data: Data) throws {
+        switch statusCode {
+        case 200..<300:
+            return
+        case 401:
+            throw CriticError.unauthorized
+        case 403:
+            throw CriticError.forbidden
+        case 404:
+            throw CriticError.notFound
+        case 400:
+            let message = extractErrorMessage(from: data)
+            throw CriticError.badRequest(message)
+        case 422:
+            let message = extractErrorMessage(from: data)
+            throw CriticError.validationFailed(message)
+        default:
+            throw CriticError.unexpectedStatusCode(statusCode)
+        }
+    }
+
+    private func extractErrorMessage(from data: Data) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) {
+            if let array = json as? [String], let first = array.first {
+                return first
+            }
+            if let dict = json as? [String: Any], let error = dict["error"] as? String {
+                return error
+            }
+        }
+        return String(data: data, encoding: .utf8) ?? "Unknown error"
+    }
+
+    private func addDeviceStatusFields(to formData: inout MultipartFormData, status: DeviceStatus) {
+        if let v = status.batteryCharging { formData.addField(name: "device_status[battery_charging]", value: String(v)) }
+        if let v = status.batteryLevel { formData.addField(name: "device_status[battery_level]", value: String(v)) }
+        if let v = status.batteryHealth { formData.addField(name: "device_status[battery_health]", value: v) }
+        if let v = status.diskFree { formData.addField(name: "device_status[disk_free]", value: String(v)) }
+        if let v = status.diskPlatform { formData.addField(name: "device_status[disk_platform]", value: String(v)) }
+        if let v = status.diskTotal { formData.addField(name: "device_status[disk_total]", value: String(v)) }
+        if let v = status.diskUsable { formData.addField(name: "device_status[disk_usable]", value: String(v)) }
+        if let v = status.memoryActive { formData.addField(name: "device_status[memory_active]", value: String(v)) }
+        if let v = status.memoryFree { formData.addField(name: "device_status[memory_free]", value: String(v)) }
+        if let v = status.memoryInactive { formData.addField(name: "device_status[memory_inactive]", value: String(v)) }
+        if let v = status.memoryPurgable { formData.addField(name: "device_status[memory_purgable]", value: String(v)) }
+        if let v = status.memoryTotal { formData.addField(name: "device_status[memory_total]", value: String(v)) }
+        if let v = status.memoryWired { formData.addField(name: "device_status[memory_wired]", value: String(v)) }
+        if let v = status.networkCellConnected { formData.addField(name: "device_status[network_cell_connected]", value: String(v)) }
+        if let v = status.networkCellSignalBars { formData.addField(name: "device_status[network_cell_signal_bars]", value: String(v)) }
+        if let v = status.networkWifiConnected { formData.addField(name: "device_status[network_wifi_connected]", value: String(v)) }
+        if let v = status.networkWifiSignalBars { formData.addField(name: "device_status[network_wifi_signal_bars]", value: String(v)) }
     }
 }

--- a/Sources/Critic/API/Endpoints.swift
+++ b/Sources/Critic/API/Endpoints.swift
@@ -4,5 +4,26 @@ import Foundation
 public enum Endpoints {
 
     /// The API version path prefix.
-    static let apiVersion = "v3"
+    static let basePath = "api/v3"
+
+    /// POST /api/v3/ping
+    static func ping(baseURL: URL) -> URL {
+        baseURL.appending(path: "\(basePath)/ping")
+    }
+
+    /// POST /api/v3/bug_reports (create)
+    /// GET  /api/v3/bug_reports (list)
+    static func bugReports(baseURL: URL) -> URL {
+        baseURL.appending(path: "\(basePath)/bug_reports")
+    }
+
+    /// GET /api/v3/bug_reports/:id
+    static func bugReport(baseURL: URL, id: String) -> URL {
+        baseURL.appending(path: "\(basePath)/bug_reports/\(id)")
+    }
+
+    /// GET /api/v3/devices
+    static func devices(baseURL: URL) -> URL {
+        baseURL.appending(path: "\(basePath)/devices")
+    }
 }

--- a/Sources/Critic/API/MultipartFormData.swift
+++ b/Sources/Critic/API/MultipartFormData.swift
@@ -9,9 +9,51 @@ public struct MultipartFormData: Sendable {
     }
 
     private let boundary: String
+    private var parts: [Data]
 
     /// Creates a new multipart form data builder.
     public init(boundary: String = UUID().uuidString) {
         self.boundary = boundary
+        self.parts = []
+    }
+
+    /// Adds a text field to the form data.
+    public mutating func addField(name: String, value: String) {
+        var part = Data()
+        part.append("--\(boundary)\r\n")
+        part.append("Content-Disposition: form-data; name=\"\(name)\"\r\n")
+        part.append("\r\n")
+        part.append("\(value)\r\n")
+        parts.append(part)
+    }
+
+    /// Adds a file to the form data.
+    public mutating func addFile(name: String, filename: String, mimeType: String, data: Data) {
+        var part = Data()
+        part.append("--\(boundary)\r\n")
+        part.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        part.append("Content-Type: \(mimeType)\r\n")
+        part.append("\r\n")
+        part.append(data)
+        part.append("\r\n")
+        parts.append(part)
+    }
+
+    /// Builds the final request body data.
+    public func build() -> Data {
+        var body = Data()
+        for part in parts {
+            body.append(part)
+        }
+        body.append("--\(boundary)--\r\n")
+        return body
+    }
+}
+
+extension Data {
+    mutating func append(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            append(data)
+        }
     }
 }

--- a/Sources/Critic/API/MultipartFormData.swift
+++ b/Sources/Critic/API/MultipartFormData.swift
@@ -27,11 +27,21 @@ public struct MultipartFormData: Sendable {
         parts.append(part)
     }
 
+    /// Sanitizes a filename for safe use in a Content-Disposition header.
+    private static func sanitizeFilename(_ filename: String) -> String {
+        var sanitized = filename
+        sanitized = sanitized.replacingOccurrences(of: "\"", with: "\\\"")
+        sanitized = sanitized.replacingOccurrences(of: "\r", with: "")
+        sanitized = sanitized.replacingOccurrences(of: "\n", with: "")
+        return sanitized
+    }
+
     /// Adds a file to the form data.
     public mutating func addFile(name: String, filename: String, mimeType: String, data: Data) {
+        let safeFilename = Self.sanitizeFilename(filename)
         var part = Data()
         part.append("--\(boundary)\r\n")
-        part.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        part.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(safeFilename)\"\r\n")
         part.append("Content-Type: \(mimeType)\r\n")
         part.append("\r\n")
         part.append(data)

--- a/Sources/Critic/Critic.swift
+++ b/Sources/Critic/Critic.swift
@@ -24,6 +24,11 @@ public final class Critic: @unchecked Sendable {
         self.baseURL = URL(string: "https://critic.inventiv.io")!
     }
 
+    /// Thread-safe read of mutable properties used by public methods.
+    private func lockedState() -> (api: CriticAPI?, appInstallId: String?) {
+        lock.withLock { (self.api, self.appInstallId) }
+    }
+
     /// Initialize the SDK with an organization API token.
     /// Performs a ping to register the device and app install.
     #if canImport(UIKit)
@@ -34,11 +39,11 @@ public final class Critic: @unchecked Sendable {
     ) async throws {
         let resolvedBaseURL = baseURL ?? self.baseURL
 
-        lock.lock()
-        self.apiToken = apiToken
-        self.baseURL = resolvedBaseURL
-        self.api = CriticAPI(baseURL: resolvedBaseURL, apiToken: apiToken)
-        lock.unlock()
+        lock.withLock {
+            self.apiToken = apiToken
+            self.baseURL = resolvedBaseURL
+            self.api = CriticAPI(baseURL: resolvedBaseURL, apiToken: apiToken)
+        }
 
         let deviceInfo = DeviceInfo()
         let deviceInfoData = deviceInfo.collectDeviceInfoData()
@@ -66,12 +71,12 @@ public final class Critic: @unchecked Sendable {
             deviceStatus: deviceStatus
         )
 
-        guard let api else { throw CriticError.notInitialized }
+        guard let api = lock.withLock({ self.api }) else { throw CriticError.notInitialized }
         let appInstall = try await api.ping(pingRequest)
 
-        lock.lock()
-        self.appInstallId = appInstall.id
-        lock.unlock()
+        lock.withLock {
+            self.appInstallId = appInstall.id
+        }
     }
     #endif
 
@@ -80,6 +85,8 @@ public final class Critic: @unchecked Sendable {
         _ report: BugReportInput,
         attachments: [(filename: String, mimeType: String, data: Data)]? = nil
     ) async throws -> BugReport {
+        let (api, appInstallId) = lockedState()
+
         guard let api else { throw CriticError.notInitialized }
         guard let appInstallId else { throw CriticError.notInitialized }
 

--- a/Sources/Critic/Critic.swift
+++ b/Sources/Critic/Critic.swift
@@ -1,10 +1,100 @@
 import Foundation
 
 /// Primary entry point for the Critic SDK.
-public final class Critic: Sendable {
+public final class Critic: @unchecked Sendable {
 
     /// Shared singleton instance.
     public static let shared = Critic()
 
-    private init() {}
+    /// The API client, available after initialization.
+    public private(set) var api: CriticAPI?
+
+    /// The app install ID, set after a successful ping.
+    public private(set) var appInstallId: String?
+
+    /// The API token used for this session.
+    public private(set) var apiToken: String?
+
+    /// The base URL for the Critic API.
+    public private(set) var baseURL: URL
+
+    private let lock = NSLock()
+
+    private init() {
+        self.baseURL = URL(string: "https://critic.inventiv.io")!
+    }
+
+    /// Initialize the SDK with an organization API token.
+    /// Performs a ping to register the device and app install.
+    #if canImport(UIKit)
+    @MainActor
+    public func initialize(
+        apiToken: String,
+        baseURL: URL? = nil
+    ) async throws {
+        let resolvedBaseURL = baseURL ?? self.baseURL
+
+        lock.lock()
+        self.apiToken = apiToken
+        self.baseURL = resolvedBaseURL
+        self.api = CriticAPI(baseURL: resolvedBaseURL, apiToken: apiToken)
+        lock.unlock()
+
+        let deviceInfo = DeviceInfo()
+        let deviceInfoData = deviceInfo.collectDeviceInfoData()
+        let deviceStatus = deviceInfo.collectDeviceStatus()
+
+        let bundle = Bundle.main
+        let appName = bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? "Unknown"
+        let bundleId = bundle.bundleIdentifier ?? "unknown"
+        let versionName = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+        let buildNumber = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "0"
+
+        let appInfo = AppInfo(
+            name: appName,
+            package: bundleId,
+            platform: "iOS",
+            version: AppVersionInfo(code: buildNumber, name: versionName)
+        )
+
+        let pingRequest = PingRequest(
+            apiToken: apiToken,
+            app: appInfo,
+            device: deviceInfoData,
+            deviceStatus: deviceStatus
+        )
+
+        guard let api else { throw CriticError.notInitialized }
+        let appInstall = try await api.ping(pingRequest)
+
+        lock.lock()
+        self.appInstallId = appInstall.id
+        lock.unlock()
+    }
+    #endif
+
+    /// Submit a bug report with optional file attachments.
+    public func submitReport(
+        _ report: BugReportInput,
+        attachments: [(filename: String, mimeType: String, data: Data)]? = nil
+    ) async throws -> BugReport {
+        guard let api else { throw CriticError.notInitialized }
+        guard let appInstallId else { throw CriticError.notInitialized }
+
+        #if canImport(UIKit)
+        let deviceInfo = DeviceInfo()
+        let deviceStatus = await MainActor.run { deviceInfo.collectDeviceStatus() }
+        #else
+        let deviceStatus: DeviceStatus? = nil
+        #endif
+
+        return try await api.createBugReport(
+            report: report,
+            appInstallId: appInstallId,
+            attachments: attachments,
+            deviceStatus: deviceStatus
+        )
+    }
 }

--- a/Sources/Critic/Models/App.swift
+++ b/Sources/Critic/Models/App.swift
@@ -1,8 +1,20 @@
 import Foundation
 
 /// Represents an application registered with Critic.
-public struct App: Codable, Sendable {
+public struct App: Codable, Sendable, Equatable {
 
-    /// The unique identifier for this app.
+    /// The unique identifier (UUID) for this app.
     public let id: String
+
+    /// The app name.
+    public let name: String?
+
+    /// The platform (e.g. "iOS", "Android").
+    public let platform: String?
+
+    public init(id: String, name: String? = nil, platform: String? = nil) {
+        self.id = id
+        self.name = name
+        self.platform = platform
+    }
 }

--- a/Sources/Critic/Models/AppInstall.swift
+++ b/Sources/Critic/Models/AppInstall.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 /// Represents an app installation registered with Critic.
-public struct AppInstall: Codable, Sendable {
+public struct AppInstall: Codable, Sendable, Equatable {
 
-    /// The unique identifier for this app install.
+    /// The unique identifier (UUID) for this app install.
     public let id: String
+
+    public init(id: String) {
+        self.id = id
+    }
 }

--- a/Sources/Critic/Models/AppVersion.swift
+++ b/Sources/Critic/Models/AppVersion.swift
@@ -1,8 +1,20 @@
 import Foundation
 
 /// Represents a specific version of an application.
-public struct AppVersion: Codable, Sendable {
+public struct AppVersion: Codable, Sendable, Equatable {
 
-    /// The version string.
-    public let version: String
+    /// The unique identifier (UUID) for this version.
+    public let id: String?
+
+    /// The version code (build number).
+    public let code: String
+
+    /// The version name (display string).
+    public let name: String
+
+    public init(id: String? = nil, code: String, name: String) {
+        self.id = id
+        self.code = code
+        self.name = name
+    }
 }

--- a/Sources/Critic/Models/Attachment.swift
+++ b/Sources/Critic/Models/Attachment.swift
@@ -1,8 +1,48 @@
 import Foundation
 
 /// Represents a file attachment on a bug report.
-public struct Attachment: Codable, Sendable {
+public struct Attachment: Codable, Sendable, Equatable {
 
-    /// The unique identifier for this attachment.
+    /// The unique identifier (UUID) for this attachment.
     public let id: String
+
+    /// The original file name.
+    public let fileFileName: String?
+
+    /// The file size in bytes.
+    public let fileFileSize: Int?
+
+    /// The MIME content type.
+    public let fileContentType: String?
+
+    /// When the file was last updated.
+    public let fileUpdatedAt: String?
+
+    /// The URL to download the attachment.
+    public let url: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case fileFileName = "file_file_name"
+        case fileFileSize = "file_file_size"
+        case fileContentType = "file_content_type"
+        case fileUpdatedAt = "file_updated_at"
+        case url
+    }
+
+    public init(
+        id: String,
+        fileFileName: String? = nil,
+        fileFileSize: Int? = nil,
+        fileContentType: String? = nil,
+        fileUpdatedAt: String? = nil,
+        url: String? = nil
+    ) {
+        self.id = id
+        self.fileFileName = fileFileName
+        self.fileFileSize = fileFileSize
+        self.fileContentType = fileContentType
+        self.fileUpdatedAt = fileUpdatedAt
+        self.url = url
+    }
 }

--- a/Sources/Critic/Models/BugReport.swift
+++ b/Sources/Critic/Models/BugReport.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Represents a bug report submitted through Critic.
-public struct BugReport: Codable, Sendable, Equatable {
+public struct BugReport: Codable, Sendable, Equatable, PaginatedItemKey {
+
+    public static let paginatedKey = "bug_reports"
 
     /// The unique identifier (UUID) for this report.
     public let id: String

--- a/Sources/Critic/Models/BugReport.swift
+++ b/Sources/Critic/Models/BugReport.swift
@@ -1,8 +1,112 @@
 import Foundation
 
 /// Represents a bug report submitted through Critic.
-public struct BugReport: Codable, Sendable {
+public struct BugReport: Codable, Sendable, Equatable {
 
-    /// The unique identifier for this report.
+    /// The unique identifier (UUID) for this report.
     public let id: String
+
+    /// The bug report description.
+    public let description: String?
+
+    /// Arbitrary metadata as a JSON string.
+    public let metadata: String?
+
+    /// Steps to reproduce the bug.
+    public let stepsToReproduce: String?
+
+    /// An identifier for the user who submitted the report.
+    public let userIdentifier: String?
+
+    /// When the report was created.
+    public let createdAt: String?
+
+    /// When the report was last updated.
+    public let updatedAt: String?
+
+    /// The device associated with the report.
+    public let device: Device?
+
+    /// The device status at the time of the report.
+    public let deviceStatus: DeviceStatus?
+
+    /// The app version associated with the report.
+    public let appVersion: AppVersion?
+
+    /// The app associated with the report.
+    public let app: App?
+
+    /// File attachments on the report.
+    public let attachments: [Attachment]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case description
+        case metadata
+        case stepsToReproduce = "steps_to_reproduce"
+        case userIdentifier = "user_identifier"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case device
+        case deviceStatus = "device_status"
+        case appVersion = "app_version"
+        case app
+        case attachments
+    }
+
+    public init(
+        id: String,
+        description: String? = nil,
+        metadata: String? = nil,
+        stepsToReproduce: String? = nil,
+        userIdentifier: String? = nil,
+        createdAt: String? = nil,
+        updatedAt: String? = nil,
+        device: Device? = nil,
+        deviceStatus: DeviceStatus? = nil,
+        appVersion: AppVersion? = nil,
+        app: App? = nil,
+        attachments: [Attachment]? = nil
+    ) {
+        self.id = id
+        self.description = description
+        self.metadata = metadata
+        self.stepsToReproduce = stepsToReproduce
+        self.userIdentifier = userIdentifier
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.device = device
+        self.deviceStatus = deviceStatus
+        self.appVersion = appVersion
+        self.app = app
+        self.attachments = attachments
+    }
+}
+
+/// Input data for creating a new bug report.
+public struct BugReportInput: Sendable {
+
+    /// The bug description.
+    public let description: String
+
+    /// Arbitrary metadata dictionary.
+    public let metadata: [String: String]?
+
+    /// Steps to reproduce the bug.
+    public let stepsToReproduce: String?
+
+    /// An identifier for the user submitting the report.
+    public let userIdentifier: String?
+
+    public init(
+        description: String,
+        metadata: [String: String]? = nil,
+        stepsToReproduce: String? = nil,
+        userIdentifier: String? = nil
+    ) {
+        self.description = description
+        self.metadata = metadata
+        self.stepsToReproduce = stepsToReproduce
+        self.userIdentifier = userIdentifier
+    }
 }

--- a/Sources/Critic/Models/CriticError.swift
+++ b/Sources/Critic/Models/CriticError.swift
@@ -1,7 +1,22 @@
 import Foundation
 
 /// Errors that can occur when interacting with the Critic SDK.
-public enum CriticError: Error, Sendable {
+public enum CriticError: Error, Sendable, Equatable {
+
+    /// The API token is invalid (HTTP 401).
+    case unauthorized
+
+    /// Access is forbidden for the given credentials (HTTP 403).
+    case forbidden
+
+    /// The requested resource was not found (HTTP 404).
+    case notFound
+
+    /// Validation failed on the server (HTTP 422).
+    case validationFailed(String)
+
+    /// Bad request (HTTP 400).
+    case badRequest(String)
 
     /// The API returned an unexpected status code.
     case unexpectedStatusCode(Int)
@@ -10,5 +25,27 @@ public enum CriticError: Error, Sendable {
     case decodingFailed
 
     /// A network error occurred.
-    case networkError(any Error & Sendable)
+    case networkError(String)
+
+    /// The SDK has not been initialized.
+    case notInitialized
+
+    public static func == (lhs: CriticError, rhs: CriticError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unauthorized, .unauthorized),
+             (.forbidden, .forbidden),
+             (.notFound, .notFound),
+             (.decodingFailed, .decodingFailed),
+             (.notInitialized, .notInitialized):
+            return true
+        case (.validationFailed(let a), .validationFailed(let b)),
+             (.badRequest(let a), .badRequest(let b)),
+             (.networkError(let a), .networkError(let b)):
+            return a == b
+        case (.unexpectedStatusCode(let a), .unexpectedStatusCode(let b)):
+            return a == b
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/Critic/Models/Device.swift
+++ b/Sources/Critic/Models/Device.swift
@@ -1,8 +1,66 @@
 import Foundation
 
 /// Represents device information sent with reports.
-public struct Device: Codable, Sendable {
+public struct Device: Codable, Sendable, Equatable {
+
+    /// The unique identifier (UUID) for this device.
+    public let id: String?
+
+    /// A device-unique identifier.
+    public let identifier: String?
+
+    /// The device manufacturer.
+    public let manufacturer: String?
 
     /// The device model identifier.
-    public let model: String
+    public let model: String?
+
+    /// The network carrier name.
+    public let networkCarrier: String?
+
+    /// The platform (e.g. "iOS").
+    public let platform: String?
+
+    /// The platform/OS version.
+    public let platformVersion: String?
+
+    /// When the device record was created.
+    public let createdAt: String?
+
+    /// When the device record was last updated.
+    public let updatedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case identifier
+        case manufacturer
+        case model
+        case networkCarrier = "network_carrier"
+        case platform
+        case platformVersion = "platform_version"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    public init(
+        id: String? = nil,
+        identifier: String? = nil,
+        manufacturer: String? = nil,
+        model: String? = nil,
+        networkCarrier: String? = nil,
+        platform: String? = nil,
+        platformVersion: String? = nil,
+        createdAt: String? = nil,
+        updatedAt: String? = nil
+    ) {
+        self.id = id
+        self.identifier = identifier
+        self.manufacturer = manufacturer
+        self.model = model
+        self.networkCarrier = networkCarrier
+        self.platform = platform
+        self.platformVersion = platformVersion
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }

--- a/Sources/Critic/Models/Device.swift
+++ b/Sources/Critic/Models/Device.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Represents device information sent with reports.
-public struct Device: Codable, Sendable, Equatable {
+public struct Device: Codable, Sendable, Equatable, PaginatedItemKey {
+
+    public static let paginatedKey = "devices"
 
     /// The unique identifier (UUID) for this device.
     public let id: String?

--- a/Sources/Critic/Models/DeviceStatus.swift
+++ b/Sources/Critic/Models/DeviceStatus.swift
@@ -1,8 +1,126 @@
 import Foundation
 
 /// Represents the current status/state of the device.
-public struct DeviceStatus: Codable, Sendable {
+public struct DeviceStatus: Codable, Sendable, Equatable {
 
-    /// The device battery level (0.0–1.0).
-    public let batteryLevel: Float?
+    /// The unique identifier (UUID).
+    public let id: String?
+
+    /// Whether the battery is currently charging.
+    public let batteryCharging: Bool?
+
+    /// The battery level (0–100).
+    public let batteryLevel: Int?
+
+    /// The battery health description.
+    public let batteryHealth: String?
+
+    /// Free disk space in bytes.
+    public let diskFree: Int64?
+
+    /// Platform disk space in bytes.
+    public let diskPlatform: Int64?
+
+    /// Total disk space in bytes.
+    public let diskTotal: Int64?
+
+    /// Usable disk space in bytes.
+    public let diskUsable: Int64?
+
+    /// Active memory in bytes.
+    public let memoryActive: Int64?
+
+    /// Free memory in bytes.
+    public let memoryFree: Int64?
+
+    /// Inactive memory in bytes.
+    public let memoryInactive: Int64?
+
+    /// Purgable memory in bytes.
+    public let memoryPurgable: Int64?
+
+    /// Total memory in bytes.
+    public let memoryTotal: Int64?
+
+    /// Wired memory in bytes.
+    public let memoryWired: Int64?
+
+    /// Arbitrary metadata.
+    public let metadata: String?
+
+    /// Whether cellular data is connected.
+    public let networkCellConnected: Bool?
+
+    /// Cellular signal strength in bars.
+    public let networkCellSignalBars: Int?
+
+    /// Whether WiFi is connected.
+    public let networkWifiConnected: Bool?
+
+    /// WiFi signal strength in bars.
+    public let networkWifiSignalBars: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case batteryCharging = "battery_charging"
+        case batteryLevel = "battery_level"
+        case batteryHealth = "battery_health"
+        case diskFree = "disk_free"
+        case diskPlatform = "disk_platform"
+        case diskTotal = "disk_total"
+        case diskUsable = "disk_usable"
+        case memoryActive = "memory_active"
+        case memoryFree = "memory_free"
+        case memoryInactive = "memory_inactive"
+        case memoryPurgable = "memory_purgable"
+        case memoryTotal = "memory_total"
+        case memoryWired = "memory_wired"
+        case metadata
+        case networkCellConnected = "network_cell_connected"
+        case networkCellSignalBars = "network_cell_signal_bars"
+        case networkWifiConnected = "network_wifi_connected"
+        case networkWifiSignalBars = "network_wifi_signal_bars"
+    }
+
+    public init(
+        id: String? = nil,
+        batteryCharging: Bool? = nil,
+        batteryLevel: Int? = nil,
+        batteryHealth: String? = nil,
+        diskFree: Int64? = nil,
+        diskPlatform: Int64? = nil,
+        diskTotal: Int64? = nil,
+        diskUsable: Int64? = nil,
+        memoryActive: Int64? = nil,
+        memoryFree: Int64? = nil,
+        memoryInactive: Int64? = nil,
+        memoryPurgable: Int64? = nil,
+        memoryTotal: Int64? = nil,
+        memoryWired: Int64? = nil,
+        metadata: String? = nil,
+        networkCellConnected: Bool? = nil,
+        networkCellSignalBars: Int? = nil,
+        networkWifiConnected: Bool? = nil,
+        networkWifiSignalBars: Int? = nil
+    ) {
+        self.id = id
+        self.batteryCharging = batteryCharging
+        self.batteryLevel = batteryLevel
+        self.batteryHealth = batteryHealth
+        self.diskFree = diskFree
+        self.diskPlatform = diskPlatform
+        self.diskTotal = diskTotal
+        self.diskUsable = diskUsable
+        self.memoryActive = memoryActive
+        self.memoryFree = memoryFree
+        self.memoryInactive = memoryInactive
+        self.memoryPurgable = memoryPurgable
+        self.memoryTotal = memoryTotal
+        self.memoryWired = memoryWired
+        self.metadata = metadata
+        self.networkCellConnected = networkCellConnected
+        self.networkCellSignalBars = networkCellSignalBars
+        self.networkWifiConnected = networkWifiConnected
+        self.networkWifiSignalBars = networkWifiSignalBars
+    }
 }

--- a/Sources/Critic/Models/PaginatedResponse.swift
+++ b/Sources/Critic/Models/PaginatedResponse.swift
@@ -3,9 +3,53 @@ import Foundation
 /// A generic wrapper for paginated API responses.
 public struct PaginatedResponse<T: Codable & Sendable>: Codable, Sendable {
 
+    /// The total number of items across all pages.
+    public let count: Int
+
+    /// The current page number.
+    public let currentPage: Int
+
+    /// The total number of pages.
+    public let totalPages: Int
+
     /// The items in the current page.
     public let items: [T]
 
-    /// The total number of items across all pages.
-    public let totalCount: Int
+    enum CodingKeys: String, CodingKey {
+        case count
+        case currentPage = "current_page"
+        case totalPages = "total_pages"
+        case bugReports = "bug_reports"
+        case devices
+    }
+
+    public init(count: Int, currentPage: Int, totalPages: Int, items: [T]) {
+        self.count = count
+        self.currentPage = currentPage
+        self.totalPages = totalPages
+        self.items = items
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        count = try container.decode(Int.self, forKey: .count)
+        currentPage = try container.decode(Int.self, forKey: .currentPage)
+        totalPages = try container.decode(Int.self, forKey: .totalPages)
+
+        if let bugReports = try container.decodeIfPresent([T].self, forKey: .bugReports) {
+            items = bugReports
+        } else if let devices = try container.decodeIfPresent([T].self, forKey: .devices) {
+            items = devices
+        } else {
+            items = []
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(count, forKey: .count)
+        try container.encode(currentPage, forKey: .currentPage)
+        try container.encode(totalPages, forKey: .totalPages)
+        try container.encode(items, forKey: .bugReports)
+    }
 }

--- a/Sources/Critic/Models/PaginatedResponse.swift
+++ b/Sources/Critic/Models/PaginatedResponse.swift
@@ -1,7 +1,17 @@
 import Foundation
 
+/// A protocol that associates a Codable item type with its JSON key in paginated responses.
+public protocol PaginatedItemKey {
+    /// The JSON key under which items of this type appear in paginated API responses.
+    static var paginatedKey: String { get }
+}
+
 /// A generic wrapper for paginated API responses.
-public struct PaginatedResponse<T: Codable & Sendable>: Codable, Sendable {
+///
+/// The decoder discovers the items array by looking up `T.paginatedKey` if `T` conforms
+/// to `PaginatedItemKey`, otherwise it falls back to trying all non-metadata keys in the
+/// response object. This makes it extensible to new paginated endpoints without code changes.
+public struct PaginatedResponse<T: Codable & Sendable>: Sendable {
 
     /// The total number of items across all pages.
     public let count: Int
@@ -15,14 +25,6 @@ public struct PaginatedResponse<T: Codable & Sendable>: Codable, Sendable {
     /// The items in the current page.
     public let items: [T]
 
-    enum CodingKeys: String, CodingKey {
-        case count
-        case currentPage = "current_page"
-        case totalPages = "total_pages"
-        case bugReports = "bug_reports"
-        case devices
-    }
-
     public init(count: Int, currentPage: Int, totalPages: Int, items: [T]) {
         self.count = count
         self.currentPage = currentPage
@@ -30,26 +32,74 @@ public struct PaginatedResponse<T: Codable & Sendable>: Codable, Sendable {
         self.items = items
     }
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        count = try container.decode(Int.self, forKey: .count)
-        currentPage = try container.decode(Int.self, forKey: .currentPage)
-        totalPages = try container.decode(Int.self, forKey: .totalPages)
-
-        if let bugReports = try container.decodeIfPresent([T].self, forKey: .bugReports) {
-            items = bugReports
-        } else if let devices = try container.decodeIfPresent([T].self, forKey: .devices) {
-            items = devices
-        } else {
-            items = []
-        }
+    private enum MetadataKeys: String, CodingKey {
+        case count
+        case currentPage = "current_page"
+        case totalPages = "total_pages"
     }
 
+    /// Dynamic coding key for discovering item arrays by name.
+    private struct DynamicKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
+    }
+
+    private static var metadataKeyNames: Set<String> {
+        ["count", "current_page", "total_pages"]
+    }
+}
+
+extension PaginatedResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let metaContainer = try decoder.container(keyedBy: MetadataKeys.self)
+        count = try metaContainer.decode(Int.self, forKey: .count)
+        currentPage = try metaContainer.decode(Int.self, forKey: .currentPage)
+        totalPages = try metaContainer.decode(Int.self, forKey: .totalPages)
+
+        let dynamicContainer = try decoder.container(keyedBy: DynamicKey.self)
+
+        // If T declares its own paginated key, use it directly.
+        if let keyed = T.self as? any PaginatedItemKey.Type,
+           let key = DynamicKey(stringValue: keyed.paginatedKey) {
+            items = (try? dynamicContainer.decode([T].self, forKey: key)) ?? []
+            return
+        }
+
+        // Otherwise, try all non-metadata keys until we find a decodable array.
+        let allKeys = dynamicContainer.allKeys
+        let candidateKeys = allKeys.filter { !Self.metadataKeyNames.contains($0.stringValue) }
+
+        for key in candidateKeys {
+            if let decoded = try? dynamicContainer.decode([T].self, forKey: key) {
+                items = decoded
+                return
+            }
+        }
+
+        items = []
+    }
+}
+
+extension PaginatedResponse: Encodable {
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(count, forKey: .count)
-        try container.encode(currentPage, forKey: .currentPage)
-        try container.encode(totalPages, forKey: .totalPages)
-        try container.encode(items, forKey: .bugReports)
+        var metaContainer = encoder.container(keyedBy: MetadataKeys.self)
+        try metaContainer.encode(count, forKey: .count)
+        try metaContainer.encode(currentPage, forKey: .currentPage)
+        try metaContainer.encode(totalPages, forKey: .totalPages)
+
+        // Encode items under the correct key for the item type.
+        var dynamicContainer = encoder.container(keyedBy: DynamicKey.self)
+        let keyName: String
+        if let keyed = T.self as? any PaginatedItemKey.Type {
+            keyName = keyed.paginatedKey
+        } else {
+            // Fallback: use a generic "items" key.
+            keyName = "items"
+        }
+        if let key = DynamicKey(stringValue: keyName) {
+            try dynamicContainer.encode(items, forKey: key)
+        }
     }
 }

--- a/Sources/Critic/Models/PingRequest.swift
+++ b/Sources/Critic/Models/PingRequest.swift
@@ -3,6 +3,123 @@ import Foundation
 /// Represents a ping/heartbeat request to the Critic API.
 public struct PingRequest: Codable, Sendable {
 
-    /// The app install identifier.
-    public let appInstallId: String
+    /// The organization API token.
+    public let apiToken: String
+
+    /// The app information.
+    public let app: AppInfo
+
+    /// The device information.
+    public let device: DeviceInfoData
+
+    /// The current device status.
+    public let deviceStatus: DeviceStatus?
+
+    enum CodingKeys: String, CodingKey {
+        case apiToken = "api_token"
+        case app
+        case device
+        case deviceStatus = "device_status"
+    }
+
+    public init(apiToken: String, app: AppInfo, device: DeviceInfoData, deviceStatus: DeviceStatus? = nil) {
+        self.apiToken = apiToken
+        self.app = app
+        self.device = device
+        self.deviceStatus = deviceStatus
+    }
+}
+
+/// App information sent in a ping request.
+public struct AppInfo: Codable, Sendable {
+
+    /// The app name.
+    public let name: String
+
+    /// The app bundle identifier / package name.
+    public let package: String
+
+    /// The platform (e.g. "iOS").
+    public let platform: String
+
+    /// The app version.
+    public let version: AppVersionInfo
+
+    public init(name: String, package: String, platform: String = "iOS", version: AppVersionInfo) {
+        self.name = name
+        self.package = package
+        self.platform = platform
+        self.version = version
+    }
+}
+
+/// Version info sent in a ping request.
+public struct AppVersionInfo: Codable, Sendable {
+
+    /// The build number.
+    public let code: String
+
+    /// The version display name.
+    public let name: String
+
+    public init(code: String, name: String) {
+        self.code = code
+        self.name = name
+    }
+}
+
+/// Device information sent in a ping request.
+public struct DeviceInfoData: Codable, Sendable {
+
+    /// A unique device identifier.
+    public let identifier: String
+
+    /// The device manufacturer.
+    public let manufacturer: String
+
+    /// The device model.
+    public let model: String
+
+    /// The network carrier.
+    public let networkCarrier: String
+
+    /// The platform (e.g. "iOS").
+    public let platform: String
+
+    /// The platform/OS version.
+    public let platformVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case identifier
+        case manufacturer
+        case model
+        case networkCarrier = "network_carrier"
+        case platform
+        case platformVersion = "platform_version"
+    }
+
+    public init(
+        identifier: String,
+        manufacturer: String,
+        model: String,
+        networkCarrier: String,
+        platform: String = "iOS",
+        platformVersion: String
+    ) {
+        self.identifier = identifier
+        self.manufacturer = manufacturer
+        self.model = model
+        self.networkCarrier = networkCarrier
+        self.platform = platform
+        self.platformVersion = platformVersion
+    }
+}
+
+/// Response wrapper for the ping endpoint.
+struct PingResponse: Codable, Sendable {
+    let appInstall: AppInstall
+
+    enum CodingKeys: String, CodingKey {
+        case appInstall = "app_install"
+    }
 }

--- a/Sources/Critic/UI/FeedbackView.swift
+++ b/Sources/Critic/UI/FeedbackView.swift
@@ -1,14 +1,142 @@
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(UIKit)
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// A SwiftUI view for collecting user feedback.
 @available(iOS 16.0, *)
 public struct FeedbackView: View {
 
-    public init() {}
+    @State private var description: String = ""
+    @State private var stepsToReproduce: String = ""
+    @State private var isPickerPresented: Bool = false
+    @State private var attachedFiles: [(filename: String, mimeType: String, data: Data)] = []
+    @State private var isSubmitting: Bool = false
+    @State private var errorMessage: String?
+    @State private var didSubmit: Bool = false
+
+    /// Called when the user submits the report. Returns the created BugReport.
+    public var onSubmit: ((BugReport) -> Void)?
+
+    /// Called when the user cancels.
+    public var onCancel: (() -> Void)?
+
+    /// Optional user identifier to attach to the report.
+    public var userIdentifier: String?
+
+    public init(
+        onSubmit: ((BugReport) -> Void)? = nil,
+        onCancel: (() -> Void)? = nil,
+        userIdentifier: String? = nil
+    ) {
+        self.onSubmit = onSubmit
+        self.onCancel = onCancel
+        self.userIdentifier = userIdentifier
+    }
 
     public var body: some View {
-        Text("Feedback")
+        NavigationStack {
+            Form {
+                Section("Description") {
+                    TextEditor(text: $description)
+                        .frame(minHeight: 100)
+                        .accessibilityIdentifier("feedback_description")
+                }
+
+                Section("Steps to Reproduce") {
+                    TextEditor(text: $stepsToReproduce)
+                        .frame(minHeight: 80)
+                        .accessibilityIdentifier("feedback_steps")
+                }
+
+                Section("Attachments") {
+                    ForEach(Array(attachedFiles.enumerated()), id: \.offset) { index, file in
+                        HStack {
+                            Text(file.filename)
+                            Spacer()
+                            Button("Remove") {
+                                attachedFiles.remove(at: index)
+                            }
+                            .foregroundStyle(.red)
+                        }
+                    }
+                    Button("Add File") {
+                        isPickerPresented = true
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Submit Feedback")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onCancel?()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Submit") {
+                        Task { await submit() }
+                    }
+                    .disabled(description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+                }
+            }
+            .fileImporter(
+                isPresented: $isPickerPresented,
+                allowedContentTypes: [.item],
+                allowsMultipleSelection: true
+            ) { result in
+                handleFileImport(result)
+            }
+        }
+    }
+
+    private func submit() async {
+        isSubmitting = true
+        errorMessage = nil
+
+        let input = BugReportInput(
+            description: description,
+            stepsToReproduce: stepsToReproduce.isEmpty ? nil : stepsToReproduce,
+            userIdentifier: userIdentifier
+        )
+
+        do {
+            let bugReport = try await Critic.shared.submitReport(
+                input,
+                attachments: attachedFiles.isEmpty ? nil : attachedFiles
+            )
+            didSubmit = true
+            onSubmit?(bugReport)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isSubmitting = false
+    }
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            for url in urls {
+                guard url.startAccessingSecurityScopedResource() else { continue }
+                defer { url.stopAccessingSecurityScopedResource() }
+                if let data = try? Data(contentsOf: url) {
+                    let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+                    attachedFiles.append((
+                        filename: url.lastPathComponent,
+                        mimeType: mimeType,
+                        data: data
+                    ))
+                }
+            }
+        case .failure:
+            break
+        }
     }
 }
 #endif

--- a/Sources/Critic/UI/FeedbackViewController.swift
+++ b/Sources/Critic/UI/FeedbackViewController.swift
@@ -1,13 +1,53 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(SwiftUI)
 import UIKit
+import SwiftUI
 
 /// A UIKit view controller for collecting user feedback.
+/// Wraps the SwiftUI FeedbackView using UIHostingController.
 @available(iOS 16.0, *)
 public final class FeedbackViewController: UIViewController {
+
+    /// Called when a bug report is successfully submitted.
+    public var onSubmit: ((BugReport) -> Void)?
+
+    /// Called when the user cancels feedback.
+    public var onCancel: (() -> Void)?
+
+    /// Optional user identifier to attach to the report.
+    public var userIdentifier: String?
+
+    private var hostingController: UIHostingController<FeedbackView>?
 
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+
+        let feedbackView = FeedbackView(
+            onSubmit: { [weak self] bugReport in
+                self?.onSubmit?(bugReport)
+                self?.dismiss(animated: true)
+            },
+            onCancel: { [weak self] in
+                self?.onCancel?()
+                self?.dismiss(animated: true)
+            },
+            userIdentifier: userIdentifier
+        )
+
+        let hosting = UIHostingController(rootView: feedbackView)
+        addChild(hosting)
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hosting.view)
+
+        NSLayoutConstraint.activate([
+            hosting.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hosting.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hosting.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hosting.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        hosting.didMove(toParent: self)
+        hostingController = hosting
     }
 }
 #endif

--- a/Sources/Critic/Utilities/DeviceInfo.swift
+++ b/Sources/Critic/Utilities/DeviceInfo.swift
@@ -67,6 +67,7 @@ public struct DeviceInfo: Sendable {
     #endif
 
     /// Returns the vendor identifier or a generated UUID.
+    @MainActor
     private func identifierForVendor() -> String {
         #if canImport(UIKit)
         return UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString

--- a/Sources/Critic/Utilities/DeviceInfo.swift
+++ b/Sources/Critic/Utilities/DeviceInfo.swift
@@ -3,9 +3,125 @@ import UIKit
 #endif
 import Foundation
 
-/// Collects device information using native APIs.
+/// Collects device information using native iOS APIs.
 public struct DeviceInfo: Sendable {
 
     /// Creates a new DeviceInfo collector.
     public init() {}
+
+    #if canImport(UIKit)
+    /// Collects current device information for a ping request.
+    @MainActor
+    public func collectDeviceInfoData() -> DeviceInfoData {
+        let processInfo = ProcessInfo.processInfo
+
+        return DeviceInfoData(
+            identifier: identifierForVendor(),
+            manufacturer: "Apple",
+            model: modelIdentifier(),
+            networkCarrier: carrierName(),
+            platform: "iOS",
+            platformVersion: processInfo.operatingSystemVersionString
+        )
+    }
+
+    /// Collects current device status (battery, disk, memory).
+    @MainActor
+    public func collectDeviceStatus() -> DeviceStatus {
+        let device = UIDevice.current
+        device.isBatteryMonitoringEnabled = true
+
+        let batteryLevel = device.batteryLevel >= 0 ? Int(device.batteryLevel * 100) : nil
+        let batteryCharging: Bool? = {
+            switch device.batteryState {
+            case .charging, .full: return true
+            case .unplugged: return false
+            case .unknown: return nil
+            @unknown default: return nil
+            }
+        }()
+
+        let diskInfo = diskSpace()
+        let memoryInfo = memoryStatus()
+
+        return DeviceStatus(
+            batteryCharging: batteryCharging,
+            batteryLevel: batteryLevel,
+            batteryHealth: nil,
+            diskFree: diskInfo.free,
+            diskPlatform: nil,
+            diskTotal: diskInfo.total,
+            diskUsable: diskInfo.free,
+            memoryActive: nil,
+            memoryFree: memoryInfo.free,
+            memoryInactive: nil,
+            memoryPurgable: nil,
+            memoryTotal: memoryInfo.total,
+            memoryWired: nil,
+            networkCellConnected: nil,
+            networkCellSignalBars: nil,
+            networkWifiConnected: nil,
+            networkWifiSignalBars: nil
+        )
+    }
+    #endif
+
+    /// Returns the vendor identifier or a generated UUID.
+    private func identifierForVendor() -> String {
+        #if canImport(UIKit)
+        return UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        #else
+        return UUID().uuidString
+        #endif
+    }
+
+    /// Returns the hardware model identifier (e.g. "iPhone15,2").
+    private func modelIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        return machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+    }
+
+    /// Returns the carrier name, or "Unknown" if unavailable.
+    private func carrierName() -> String {
+        return "Unknown"
+    }
+
+    /// Returns disk space information.
+    private func diskSpace() -> (free: Int64?, total: Int64?) {
+        let fileManager = FileManager.default
+        guard let attributes = try? fileManager.attributesOfFileSystem(forPath: NSHomeDirectory()) else {
+            return (nil, nil)
+        }
+        let free = attributes[.systemFreeSize] as? Int64
+        let total = attributes[.systemSize] as? Int64
+        return (free, total)
+    }
+
+    /// Returns memory usage information.
+    private func memoryStatus() -> (free: Int64?, total: Int64?) {
+        let total = Int64(ProcessInfo.processInfo.physicalMemory)
+        // Approximate free memory using available memory
+        var pageSize: vm_size_t = 0
+        host_page_size(mach_host_self(), &pageSize)
+
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size)
+
+        let result = withUnsafeMutablePointer(to: &stats) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, intPtr, &count)
+            }
+        }
+
+        if result == KERN_SUCCESS {
+            let free = Int64(stats.free_count) * Int64(pageSize)
+            return (free, total)
+        }
+        return (nil, total)
+    }
 }

--- a/Sources/Critic/Utilities/ShakeDetector.swift
+++ b/Sources/Critic/Utilities/ShakeDetector.swift
@@ -1,12 +1,62 @@
 #if canImport(UIKit)
 import UIKit
 
-/// Detects device shake gestures to trigger feedback collection.
+/// A UIWindow subclass that detects shake gestures to trigger feedback collection.
+@available(iOS 16.0, *)
+@MainActor
+public final class ShakeDetectingWindow: UIWindow {
+
+    /// Called when a shake gesture is detected.
+    public var onShake: (() -> Void)?
+
+    public override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        super.motionEnded(motion, with: event)
+        if motion == .motionShake {
+            onShake?()
+        }
+    }
+}
+
+/// Manages shake detection and feedback presentation.
 @available(iOS 16.0, *)
 @MainActor
 public final class ShakeDetector {
 
+    private weak var window: ShakeDetectingWindow?
+
     /// Creates a new shake detector.
     public init() {}
+
+    /// Installs the shake detector on the given window.
+    /// When a shake is detected, the FeedbackViewController is presented.
+    public func install(on window: ShakeDetectingWindow) {
+        self.window = window
+        window.onShake = { [weak self] in
+            self?.presentFeedback()
+        }
+    }
+
+    /// Presents the feedback view controller.
+    public func presentFeedback() {
+        guard let rootVC = window?.rootViewController else { return }
+
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+
+        // Don't present if already showing feedback
+        if topVC is FeedbackViewController { return }
+
+        let feedbackVC = FeedbackViewController()
+        feedbackVC.modalPresentationStyle = .formSheet
+        feedbackVC.onCancel = {
+            topVC.dismiss(animated: true)
+        }
+        feedbackVC.onSubmit = { _ in
+            topVC.dismiss(animated: true)
+        }
+        topVC.present(feedbackVC, animated: true)
+    }
 }
 #endif

--- a/Tests/CriticTests/CriticTests.swift
+++ b/Tests/CriticTests/CriticTests.swift
@@ -1,36 +1,505 @@
 import Testing
+import Foundation
 @testable import Critic
 
-@Test func criticSharedInstanceExists() {
-    let instance = Critic.shared
-    #expect(instance != nil)
+// MARK: - Model Tests
+
+@Test func appDecoding() throws {
+    let json = """
+    {"id": "abc-123", "name": "TestApp", "platform": "iOS"}
+    """
+    let app = try JSONDecoder().decode(App.self, from: Data(json.utf8))
+    #expect(app.id == "abc-123")
+    #expect(app.name == "TestApp")
+    #expect(app.platform == "iOS")
 }
 
-@Test func criticAPIInitialization() throws {
-    let url = try #require(URL(string: "https://api.example.com"))
-    let api = CriticAPI(baseURL: url)
-    #expect(api.baseURL == url)
+@Test func appDecodingMinimal() throws {
+    let json = """
+    {"id": "abc-123"}
+    """
+    let app = try JSONDecoder().decode(App.self, from: Data(json.utf8))
+    #expect(app.id == "abc-123")
+    #expect(app.name == nil)
+    #expect(app.platform == nil)
 }
+
+@Test func appInstallDecoding() throws {
+    let json = """
+    {"id": "install-uuid-456"}
+    """
+    let install = try JSONDecoder().decode(AppInstall.self, from: Data(json.utf8))
+    #expect(install.id == "install-uuid-456")
+}
+
+@Test func appVersionDecoding() throws {
+    let json = """
+    {"id": "ver-uuid", "code": "42", "name": "2.1.0"}
+    """
+    let version = try JSONDecoder().decode(AppVersion.self, from: Data(json.utf8))
+    #expect(version.id == "ver-uuid")
+    #expect(version.code == "42")
+    #expect(version.name == "2.1.0")
+}
+
+@Test func attachmentDecodingWithSnakeCaseKeys() throws {
+    let json = """
+    {
+        "id": "att-uuid",
+        "file_file_name": "screenshot.png",
+        "file_file_size": 12345,
+        "file_content_type": "image/png",
+        "file_updated_at": "2026-01-01T00:00:00Z",
+        "url": "https://example.com/screenshot.png"
+    }
+    """
+    let att = try JSONDecoder().decode(Attachment.self, from: Data(json.utf8))
+    #expect(att.id == "att-uuid")
+    #expect(att.fileFileName == "screenshot.png")
+    #expect(att.fileFileSize == 12345)
+    #expect(att.fileContentType == "image/png")
+    #expect(att.fileUpdatedAt == "2026-01-01T00:00:00Z")
+    #expect(att.url == "https://example.com/screenshot.png")
+}
+
+@Test func bugReportDecodingFull() throws {
+    let json = """
+    {
+        "id": "br-uuid",
+        "description": "App crashes on launch",
+        "metadata": "{\\"key\\":\\"value\\"}",
+        "steps_to_reproduce": "1. Open app\\n2. See crash",
+        "user_identifier": "user@example.com",
+        "created_at": "2026-03-27T10:00:00Z",
+        "updated_at": "2026-03-27T11:00:00Z",
+        "device": {"id": "dev-uuid", "model": "iPhone15,2"},
+        "device_status": {"battery_level": 85, "battery_charging": true},
+        "app_version": {"code": "10", "name": "1.5.0"},
+        "app": {"id": "app-uuid", "name": "TestApp"},
+        "attachments": [{"id": "att-uuid"}]
+    }
+    """
+    let report = try JSONDecoder().decode(BugReport.self, from: Data(json.utf8))
+    #expect(report.id == "br-uuid")
+    #expect(report.description == "App crashes on launch")
+    #expect(report.stepsToReproduce == "1. Open app\n2. See crash")
+    #expect(report.userIdentifier == "user@example.com")
+    #expect(report.device?.model == "iPhone15,2")
+    #expect(report.deviceStatus?.batteryLevel == 85)
+    #expect(report.deviceStatus?.batteryCharging == true)
+    #expect(report.appVersion?.code == "10")
+    #expect(report.app?.name == "TestApp")
+    #expect(report.attachments?.count == 1)
+}
+
+@Test func bugReportDecodingMinimal() throws {
+    let json = """
+    {"id": "br-uuid"}
+    """
+    let report = try JSONDecoder().decode(BugReport.self, from: Data(json.utf8))
+    #expect(report.id == "br-uuid")
+    #expect(report.description == nil)
+    #expect(report.device == nil)
+    #expect(report.attachments == nil)
+}
+
+@Test func deviceDecodingWithSnakeCaseKeys() throws {
+    let json = """
+    {
+        "id": "dev-uuid",
+        "identifier": "AABB-1122",
+        "manufacturer": "Apple",
+        "model": "iPhone15,2",
+        "network_carrier": "Verizon",
+        "platform": "iOS",
+        "platform_version": "17.0",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-03-01T00:00:00Z"
+    }
+    """
+    let device = try JSONDecoder().decode(Device.self, from: Data(json.utf8))
+    #expect(device.id == "dev-uuid")
+    #expect(device.identifier == "AABB-1122")
+    #expect(device.manufacturer == "Apple")
+    #expect(device.model == "iPhone15,2")
+    #expect(device.networkCarrier == "Verizon")
+    #expect(device.platform == "iOS")
+    #expect(device.platformVersion == "17.0")
+    #expect(device.createdAt == "2026-01-01T00:00:00Z")
+    #expect(device.updatedAt == "2026-03-01T00:00:00Z")
+}
+
+@Test func deviceStatusDecodingAllFields() throws {
+    let json = """
+    {
+        "id": "ds-uuid",
+        "battery_charging": true,
+        "battery_level": 85,
+        "battery_health": "Good",
+        "disk_free": 1073741824,
+        "disk_platform": 2147483648,
+        "disk_total": 137438953472,
+        "disk_usable": 128849018880,
+        "memory_active": 1073741824,
+        "memory_free": 536870912,
+        "memory_inactive": 536870912,
+        "memory_purgable": 2147483648,
+        "memory_total": 8589934592,
+        "memory_wired": 134217728,
+        "metadata": "{}",
+        "network_cell_connected": true,
+        "network_cell_signal_bars": 3,
+        "network_wifi_connected": true,
+        "network_wifi_signal_bars": 2
+    }
+    """
+    let status = try JSONDecoder().decode(DeviceStatus.self, from: Data(json.utf8))
+    #expect(status.id == "ds-uuid")
+    #expect(status.batteryCharging == true)
+    #expect(status.batteryLevel == 85)
+    #expect(status.batteryHealth == "Good")
+    #expect(status.diskFree == 1_073_741_824)
+    #expect(status.diskTotal == 137_438_953_472)
+    #expect(status.memoryTotal == 8_589_934_592)
+    #expect(status.networkCellConnected == true)
+    #expect(status.networkCellSignalBars == 3)
+    #expect(status.networkWifiConnected == true)
+    #expect(status.networkWifiSignalBars == 2)
+}
+
+@Test func deviceStatusDecodingAllNil() throws {
+    let json = """
+    {}
+    """
+    let status = try JSONDecoder().decode(DeviceStatus.self, from: Data(json.utf8))
+    #expect(status.id == nil)
+    #expect(status.batteryLevel == nil)
+    #expect(status.diskFree == nil)
+    #expect(status.memoryTotal == nil)
+}
+
+// MARK: - PaginatedResponse Tests
+
+@Test func paginatedResponseBugReportsDecoding() throws {
+    let json = """
+    {
+        "count": 2,
+        "current_page": 1,
+        "total_pages": 1,
+        "bug_reports": [
+            {"id": "br-1", "description": "Bug 1"},
+            {"id": "br-2", "description": "Bug 2"}
+        ]
+    }
+    """
+    let response = try JSONDecoder().decode(PaginatedResponse<BugReport>.self, from: Data(json.utf8))
+    #expect(response.count == 2)
+    #expect(response.currentPage == 1)
+    #expect(response.totalPages == 1)
+    #expect(response.items.count == 2)
+    #expect(response.items[0].id == "br-1")
+    #expect(response.items[1].id == "br-2")
+}
+
+@Test func paginatedResponseDevicesDecoding() throws {
+    let json = """
+    {
+        "count": 1,
+        "current_page": 1,
+        "total_pages": 1,
+        "devices": [
+            {"id": "dev-1", "model": "iPhone15,2"}
+        ]
+    }
+    """
+    let response = try JSONDecoder().decode(PaginatedResponse<Device>.self, from: Data(json.utf8))
+    #expect(response.count == 1)
+    #expect(response.items.count == 1)
+    #expect(response.items[0].id == "dev-1")
+    #expect(response.items[0].model == "iPhone15,2")
+}
+
+@Test func paginatedResponseEmptyItems() throws {
+    let json = """
+    {
+        "count": 0,
+        "current_page": 1,
+        "total_pages": 0
+    }
+    """
+    let response = try JSONDecoder().decode(PaginatedResponse<BugReport>.self, from: Data(json.utf8))
+    #expect(response.count == 0)
+    #expect(response.items.isEmpty)
+}
+
+// MARK: - PingRequest Tests
+
+@Test func pingRequestEncoding() throws {
+    let request = PingRequest(
+        apiToken: "org-token-123",
+        app: AppInfo(
+            name: "TestApp",
+            package: "com.test.app",
+            version: AppVersionInfo(code: "1", name: "1.0.0")
+        ),
+        device: DeviceInfoData(
+            identifier: "device-id",
+            manufacturer: "Apple",
+            model: "iPhone15,2",
+            networkCarrier: "Verizon",
+            platformVersion: "17.0"
+        )
+    )
+
+    let data = try JSONEncoder().encode(request)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["api_token"] as? String == "org-token-123")
+
+    let app = dict["app"] as! [String: Any]
+    #expect(app["name"] as? String == "TestApp")
+    #expect(app["package"] as? String == "com.test.app")
+    #expect(app["platform"] as? String == "iOS")
+
+    let version = app["version"] as! [String: Any]
+    #expect(version["code"] as? String == "1")
+    #expect(version["name"] as? String == "1.0.0")
+
+    let device = dict["device"] as! [String: Any]
+    #expect(device["identifier"] as? String == "device-id")
+    #expect(device["manufacturer"] as? String == "Apple")
+    #expect(device["network_carrier"] as? String == "Verizon")
+    #expect(device["platform_version"] as? String == "17.0")
+}
+
+@Test func pingRequestEncodingWithDeviceStatus() throws {
+    let status = DeviceStatus(batteryCharging: false, batteryLevel: 80)
+    let request = PingRequest(
+        apiToken: "tok",
+        app: AppInfo(name: "A", package: "p", version: AppVersionInfo(code: "1", name: "1")),
+        device: DeviceInfoData(identifier: "i", manufacturer: "Apple", model: "m", networkCarrier: "c", platformVersion: "v"),
+        deviceStatus: status
+    )
+
+    let data = try JSONEncoder().encode(request)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    let ds = dict["device_status"] as! [String: Any]
+    #expect(ds["battery_level"] as? Int == 80)
+}
+
+@Test func pingResponseDecoding() throws {
+    let json = """
+    {"app_install": {"id": "install-uuid-789"}}
+    """
+    let response = try JSONDecoder().decode(PingResponse.self, from: Data(json.utf8))
+    #expect(response.appInstall.id == "install-uuid-789")
+}
+
+// MARK: - CriticError Tests
+
+@Test func criticErrorEquality() {
+    #expect(CriticError.unauthorized == CriticError.unauthorized)
+    #expect(CriticError.forbidden == CriticError.forbidden)
+    #expect(CriticError.notFound == CriticError.notFound)
+    #expect(CriticError.decodingFailed == CriticError.decodingFailed)
+    #expect(CriticError.notInitialized == CriticError.notInitialized)
+    #expect(CriticError.unexpectedStatusCode(500) == CriticError.unexpectedStatusCode(500))
+    #expect(CriticError.unexpectedStatusCode(500) != CriticError.unexpectedStatusCode(503))
+    #expect(CriticError.validationFailed("a") == CriticError.validationFailed("a"))
+    #expect(CriticError.validationFailed("a") != CriticError.validationFailed("b"))
+    #expect(CriticError.badRequest("x") == CriticError.badRequest("x"))
+    #expect(CriticError.networkError("err") == CriticError.networkError("err"))
+    #expect(CriticError.unauthorized != CriticError.forbidden)
+}
+
+@Test func criticErrorIsError() {
+    let error: any Error = CriticError.unauthorized
+    #expect(error is CriticError)
+}
+
+// MARK: - MultipartFormData Tests
 
 @Test func multipartFormDataContentType() {
     let formData = MultipartFormData(boundary: "test-boundary")
     #expect(formData.contentType == "multipart/form-data; boundary=test-boundary")
 }
 
-@Test func paginatedResponseDecoding() throws {
-    let json = """
-    {"items": [{"id": "1"}], "totalCount": 1}
-    """
-    let data = Data(json.utf8)
-    let response = try JSONDecoder().decode(PaginatedResponse<App>.self, from: data)
-    #expect(response.items.count == 1)
-    #expect(response.totalCount == 1)
+@Test func multipartFormDataTextField() {
+    var formData = MultipartFormData(boundary: "BOUNDARY")
+    formData.addField(name: "api_token", value: "my-token")
+    let body = String(data: formData.build(), encoding: .utf8)!
+
+    #expect(body.contains("--BOUNDARY\r\n"))
+    #expect(body.contains("Content-Disposition: form-data; name=\"api_token\""))
+    #expect(body.contains("my-token"))
+    #expect(body.contains("--BOUNDARY--"))
 }
 
-@Test func criticErrorCases() {
-    let error = CriticError.unexpectedStatusCode(404)
-    #expect(error is CriticError)
+@Test func multipartFormDataFileField() {
+    var formData = MultipartFormData(boundary: "BOUNDARY")
+    let fileData = Data("file content".utf8)
+    formData.addFile(name: "bug_report[attachments][]", filename: "test.txt", mimeType: "text/plain", data: fileData)
+    let body = String(data: formData.build(), encoding: .utf8)!
 
-    let decodingError = CriticError.decodingFailed
-    #expect(decodingError is CriticError)
+    #expect(body.contains("Content-Disposition: form-data; name=\"bug_report[attachments][]\"; filename=\"test.txt\""))
+    #expect(body.contains("Content-Type: text/plain"))
+    #expect(body.contains("file content"))
+}
+
+@Test func multipartFormDataMultipleFields() {
+    var formData = MultipartFormData(boundary: "B")
+    formData.addField(name: "field1", value: "value1")
+    formData.addField(name: "field2", value: "value2")
+    formData.addFile(name: "file", filename: "f.txt", mimeType: "text/plain", data: Data("data".utf8))
+    let body = String(data: formData.build(), encoding: .utf8)!
+
+    let boundaryCount = body.components(separatedBy: "--B\r\n").count - 1
+    #expect(boundaryCount == 3) // 3 parts
+    #expect(body.hasSuffix("--B--\r\n"))
+}
+
+@Test func multipartFormDataEmptyBuild() {
+    let formData = MultipartFormData(boundary: "EMPTY")
+    let body = String(data: formData.build(), encoding: .utf8)!
+    #expect(body == "--EMPTY--\r\n")
+}
+
+// MARK: - Endpoints Tests
+
+@Test func endpointsPingURL() throws {
+    let base = try #require(URL(string: "https://critic.inventiv.io"))
+    let url = Endpoints.ping(baseURL: base)
+    #expect(url.absoluteString == "https://critic.inventiv.io/api/v3/ping")
+}
+
+@Test func endpointsBugReportsURL() throws {
+    let base = try #require(URL(string: "https://critic.inventiv.io"))
+    let url = Endpoints.bugReports(baseURL: base)
+    #expect(url.absoluteString == "https://critic.inventiv.io/api/v3/bug_reports")
+}
+
+@Test func endpointsBugReportByIdURL() throws {
+    let base = try #require(URL(string: "https://critic.inventiv.io"))
+    let url = Endpoints.bugReport(baseURL: base, id: "some-uuid")
+    #expect(url.absoluteString == "https://critic.inventiv.io/api/v3/bug_reports/some-uuid")
+}
+
+@Test func endpointsDevicesURL() throws {
+    let base = try #require(URL(string: "https://critic.inventiv.io"))
+    let url = Endpoints.devices(baseURL: base)
+    #expect(url.absoluteString == "https://critic.inventiv.io/api/v3/devices")
+}
+
+// MARK: - CriticAPI Tests
+
+@Test func criticAPIInitialization() throws {
+    let url = try #require(URL(string: "https://api.example.com"))
+    let api = CriticAPI(baseURL: url, apiToken: "test-token")
+    // Actor properties accessed synchronously in test context
+    #expect(api != nil)
+}
+
+// MARK: - Critic Singleton Tests
+
+@Test func criticSharedInstanceExists() {
+    let instance = Critic.shared
+    #expect(instance != nil)
+}
+
+@Test func criticSharedIsSameInstance() {
+    let a = Critic.shared
+    let b = Critic.shared
+    #expect(a === b)
+}
+
+@Test func criticDefaultBaseURL() {
+    let critic = Critic.shared
+    #expect(critic.baseURL.absoluteString == "https://critic.inventiv.io")
+}
+
+@Test func criticNotInitializedThrows() async {
+    // Create a fresh instance scenario - shared starts uninitialized
+    // submitReport should fail if not initialized
+    let input = BugReportInput(description: "test")
+    do {
+        _ = try await Critic.shared.submitReport(input)
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .notInitialized)
+    } catch {
+        #expect(Bool(false), "Wrong error type: \(error)")
+    }
+}
+
+// MARK: - BugReportInput Tests
+
+@Test func bugReportInputInit() {
+    let input = BugReportInput(
+        description: "Something broke",
+        metadata: ["key": "value"],
+        stepsToReproduce: "1. Do thing",
+        userIdentifier: "user@test.com"
+    )
+    #expect(input.description == "Something broke")
+    #expect(input.metadata?["key"] == "value")
+    #expect(input.stepsToReproduce == "1. Do thing")
+    #expect(input.userIdentifier == "user@test.com")
+}
+
+@Test func bugReportInputMinimal() {
+    let input = BugReportInput(description: "Bug")
+    #expect(input.description == "Bug")
+    #expect(input.metadata == nil)
+    #expect(input.stepsToReproduce == nil)
+    #expect(input.userIdentifier == nil)
+}
+
+// MARK: - Round-trip Encoding/Decoding Tests
+
+@Test func deviceStatusRoundTrip() throws {
+    let original = DeviceStatus(
+        batteryCharging: true,
+        batteryLevel: 75,
+        diskFree: 1_000_000,
+        memoryTotal: 8_000_000
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(DeviceStatus.self, from: data)
+    #expect(decoded == original)
+}
+
+@Test func deviceRoundTrip() throws {
+    let original = Device(
+        id: "uuid",
+        identifier: "AABB",
+        manufacturer: "Apple",
+        model: "iPhone15,2",
+        networkCarrier: "T-Mobile",
+        platform: "iOS",
+        platformVersion: "17.0"
+    )
+    let data = try JSONEncoder().encode(original)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    // Verify snake_case keys in JSON output
+    #expect(json["network_carrier"] as? String == "T-Mobile")
+    #expect(json["platform_version"] as? String == "17.0")
+
+    let decoded = try JSONDecoder().decode(Device.self, from: data)
+    #expect(decoded == original)
+}
+
+@Test func attachmentRoundTrip() throws {
+    let original = Attachment(
+        id: "att-1",
+        fileFileName: "test.png",
+        fileFileSize: 1024,
+        fileContentType: "image/png"
+    )
+    let data = try JSONEncoder().encode(original)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["file_file_name"] as? String == "test.png")
+    #expect(json["file_file_size"] as? Int == 1024)
+
+    let decoded = try JSONDecoder().decode(Attachment.self, from: data)
+    #expect(decoded == original)
 }

--- a/Tests/CriticTests/CriticTests.swift
+++ b/Tests/CriticTests/CriticTests.swift
@@ -232,6 +232,59 @@ import Foundation
     #expect(response.items.isEmpty)
 }
 
+@Test func paginatedResponseBugReportsRoundTrip() throws {
+    let original = PaginatedResponse<BugReport>(
+        count: 1,
+        currentPage: 1,
+        totalPages: 1,
+        items: [BugReport(id: "br-1", description: "Test")]
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(PaginatedResponse<BugReport>.self, from: data)
+    #expect(decoded.count == original.count)
+    #expect(decoded.currentPage == original.currentPage)
+    #expect(decoded.totalPages == original.totalPages)
+    #expect(decoded.items.count == 1)
+    #expect(decoded.items[0].id == "br-1")
+}
+
+@Test func paginatedResponseDevicesRoundTrip() throws {
+    let original = PaginatedResponse<Device>(
+        count: 2,
+        currentPage: 1,
+        totalPages: 1,
+        items: [
+            Device(id: "dev-1", model: "iPhone15,2"),
+            Device(id: "dev-2", model: "iPad14,1")
+        ]
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(PaginatedResponse<Device>.self, from: data)
+    #expect(decoded.count == 2)
+    #expect(decoded.items.count == 2)
+    #expect(decoded.items[0].id == "dev-1")
+    #expect(decoded.items[1].model == "iPad14,1")
+}
+
+@Test func paginatedResponseUnknownTypeDecodesViaFallback() throws {
+    // AppVersion doesn't conform to PaginatedItemKey, so the decoder
+    // should fall back to trying all non-metadata keys.
+    let json = """
+    {
+        "count": 1,
+        "current_page": 1,
+        "total_pages": 1,
+        "app_versions": [
+            {"id": "ver-1", "code": "10", "name": "1.0.0"}
+        ]
+    }
+    """
+    let response = try JSONDecoder().decode(PaginatedResponse<AppVersion>.self, from: Data(json.utf8))
+    #expect(response.count == 1)
+    #expect(response.items.count == 1)
+    #expect(response.items[0].id == "ver-1")
+}
+
 // MARK: - PingRequest Tests
 
 @Test func pingRequestEncoding() throws {
@@ -362,6 +415,23 @@ import Foundation
     let formData = MultipartFormData(boundary: "EMPTY")
     let body = String(data: formData.build(), encoding: .utf8)!
     #expect(body == "--EMPTY--\r\n")
+}
+
+@Test func multipartFormDataFilenameSanitizesQuotes() {
+    var formData = MultipartFormData(boundary: "B")
+    let fileData = Data("data".utf8)
+    formData.addFile(name: "file", filename: "file\"name.txt", mimeType: "text/plain", data: fileData)
+    let body = String(data: formData.build(), encoding: .utf8)!
+    #expect(body.contains("filename=\"file\\\"name.txt\""))
+    #expect(!body.contains("filename=\"file\"name.txt\""))
+}
+
+@Test func multipartFormDataFilenameSanitizesNewlines() {
+    var formData = MultipartFormData(boundary: "B")
+    let fileData = Data("data".utf8)
+    formData.addFile(name: "file", filename: "file\r\nname.txt", mimeType: "text/plain", data: fileData)
+    let body = String(data: formData.build(), encoding: .utf8)!
+    #expect(body.contains("filename=\"filename.txt\""))
 }
 
 // MARK: - Endpoints Tests


### PR DESCRIPTION
## Summary

- Implement complete v3 API client as a Swift actor (`CriticAPI`) with async/await URLSession, covering all endpoints: ping, createBugReport, listBugReports, getBugReport, listDevices
- Flesh out all Codable models (App, AppInstall, AppVersion, Attachment, BugReport, Device, DeviceStatus, PaginatedResponse, PingRequest) with full fields, CodingKeys for snake_case mapping, and UUID string IDs per v3 contract
- Add typed errors (unauthorized, forbidden, notFound, validationFailed, badRequest, networkError), multipart form data builder, native device info collection, SwiftUI FeedbackView with file picker, UIKit FeedbackViewController wrapper, and shake-to-feedback via UIWindow subclass
- Comprehensive test suite covering model encoding/decoding, round-trips, multipart form data, endpoints, error cases, and singleton behavior

## Test plan

- [ ] CI builds the Swift package successfully
- [ ] All unit tests pass (`swift test`)
- [ ] Models correctly encode/decode snake_case JSON from the v3 API
- [ ] PaginatedResponse handles both `bug_reports` and `devices` collection keys
- [ ] CriticError maps HTTP status codes correctly
- [ ] MultipartFormData produces valid multipart bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)