### PR TITLE
iOS: Add tests, documentation & release prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,37 @@ permissions:
   contents: read
 
 jobs:
+  build-and-test:
+    name: Build & Test (Xcode ${{ matrix.xcode }})
+    if: github.event_name != 'schedule'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode: "16.2"
+            runner: macos-15
+          - xcode: "16.0"
+            runner: macos-15
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Build
+        run: |
+          xcodebuild build \
+            -scheme Critic \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            | tail -20
+      - name: Test
+        run: |
+          xcodebuild test \
+            -scheme Critic \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            | tail -40
+
   lint:
     name: Pod Lint
     if: github.event_name != 'schedule'

--- a/Example/Package.swift
+++ b/Example/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "CriticExample",
+    platforms: [
+        .iOS(.v16)
+    ],
+    dependencies: [
+        .package(path: "..")
+    ],
+    targets: [
+        .executableTarget(
+            name: "CriticExample",
+            dependencies: [
+                .product(name: "Critic", package: "inventiv-critic-ios")
+            ],
+            path: "Sources"
+        )
+    ]
+)

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,0 +1,15 @@
+# Critic SDK Example
+
+A minimal SwiftUI app demonstrating the Critic iOS SDK.
+
+## Running the Example
+
+1. Open `Package.swift` in Xcode.
+2. Replace `"YOUR_API_TOKEN"` in `CriticExampleApp.swift` with your API token from the [Critic Web Portal](https://critic.inventiv.io/products).
+3. Select an iOS Simulator and run.
+
+## Features Demonstrated
+
+- SDK initialization with `Critic.shared.initialize()`
+- Built-in feedback UI with `FeedbackView`
+- Programmatic report submission with `Critic.shared.submitReport()`

--- a/Example/Sources/CriticExampleApp.swift
+++ b/Example/Sources/CriticExampleApp.swift
@@ -1,0 +1,84 @@
+#if canImport(SwiftUI) && canImport(UIKit)
+import SwiftUI
+import Critic
+
+@main
+struct CriticExampleApp: App {
+    init() {
+        Task {
+            do {
+                // Replace with your API token from https://critic.inventiv.io/products
+                try await Critic.shared.initialize(apiToken: "YOUR_API_TOKEN")
+                print("Critic SDK initialized successfully")
+            } catch {
+                print("Failed to initialize Critic: \(error)")
+            }
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    @State private var showFeedback = false
+    @State private var lastReportId: String?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Text("Critic SDK Example")
+                    .font(.title)
+
+                if let reportId = lastReportId {
+                    Text("Last report: \(reportId)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Send Feedback") {
+                    showFeedback = true
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Submit Programmatically") {
+                    Task { await submitReport() }
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding()
+            .navigationTitle("Example")
+            .sheet(isPresented: $showFeedback) {
+                FeedbackView(
+                    onSubmit: { report in
+                        lastReportId = report.id
+                        showFeedback = false
+                    },
+                    onCancel: {
+                        showFeedback = false
+                    }
+                )
+            }
+        }
+    }
+
+    private func submitReport() async {
+        let input = BugReportInput(
+            description: "Test report from example app",
+            metadata: ["source": "example"],
+            stepsToReproduce: "1. Opened example app\n2. Tapped Submit"
+        )
+
+        do {
+            let report = try await Critic.shared.submitReport(input)
+            lastReportId = report.id
+            print("Report submitted: \(report.id)")
+        } catch {
+            print("Failed to submit report: \(error)")
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -1,197 +1,283 @@
-[![Version](https://img.shields.io/cocoapods/v/Critic.svg?style=flat)](http://cocoapods.org/pods/Critic)
-[![License](https://img.shields.io/cocoapods/l/Critic.svg?style=flat)](http://cocoapods.org/pods/Critic)
-[![Platform](https://img.shields.io/cocoapods/p/Critic.svg?style=flat)](http://cocoapods.org/pods/Critic)
+# Inventiv Critic iOS SDK
 
-# Inventiv Critic iOS Library
+[![CI](https://github.com/twinsunllc/inventiv-critic-ios/actions/workflows/ci.yml/badge.svg)](https://github.com/twinsunllc/inventiv-critic-ios/actions/workflows/ci.yml)
+[![Swift 6.0](https://img.shields.io/badge/Swift-6.0-orange.svg)](https://swift.org)
+[![Platforms](https://img.shields.io/badge/Platforms-iOS%2016+-blue.svg)](https://developer.apple.com/ios/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-Use this library to add [Inventiv Critic](https://inventiv.io/critic/) to your iOS app.
-
-![Critic iOS feedback reporting screen](https://assets.inventiv.io/github/inventiv-critic-ios/critic-ios-half-shot-feedback-screen.png)
-
-## Example
-
-To run the example project, clone the repo, and run `pod install` from the Example directory first.
+A Swift SDK for collecting actionable customer feedback via [Inventiv Critic](https://inventiv.io/critic/). Built with modern Swift concurrency (async/await), strict Sendable conformance, and zero external dependencies.
 
 ## Installation
 
-1. Add the Critic pod to your `Podfile`.
+### Swift Package Manager (Recommended)
+
+Add the package to your `Package.swift` dependencies:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/twinsunllc/inventiv-critic-ios.git", from: "1.0.0")
+]
+```
+
+Then add `"Critic"` to the target's dependencies:
+
+```swift
+.target(
+    name: "YourApp",
+    dependencies: [
+        .product(name: "Critic", package: "inventiv-critic-ios")
+    ]
+)
+```
+
+Or in Xcode: **File > Add Package Dependencies...** and enter:
+
+```
+https://github.com/twinsunllc/inventiv-critic-ios
+```
+
+### CocoaPods
+
+Add `Critic` to your `Podfile`:
+
 ```ruby
-pod 'Critic'
+pod 'Critic', '~> 1.0'
 ```
-2. Find your Product Access Token in the [Critic Web Portal](https://critic.inventiv.io/products) by viewing your Product's details.
-3. Initialize Critic by starting it from your `AppDelegate`.
+
+Then run:
+
+```bash
+bundle exec pod install
+```
+
+## Quick Start
+
+### 1. Initialize the SDK
+
+Call `initialize` early in your app lifecycle — typically in your `AppDelegate` or `App` struct:
+
 ```swift
-// Swift
-Critic.instance().start("YOUR_PRODUCT_ACCESS_TOKEN")
-```
+import Critic
 
-```objective-c
-// Objective-C
-[[Critic instance] start:@"YOUR_PRODUCT_ACCESS_TOKEN"];
-```
-### Configuration
-
-#### Shake to Send Feedback Report
-By default, Critic will prompt your users for feedback when they shake their device. You can disable this if desired.
-```swift
-// Swift
-Critic.instance().preventShakeDetection()
-```
-
-```objective-c
-// Objective-C
-[[Critic instance] preventShakeDetection];
-```
-
-#### Log Capture
-
-By default, devices that are not connected to a debug session will pipe console output (`stderr` and `stdout`) to a log file, which is 
-included with submitted Reports. You can disable this behavior prior to starting Critic.
-```swift
-// Swift
-Critic.instance().preventLogCapture()
-```
-
-```objective-c
-// Objective-C
-[[Critic instance] preventLogCapture];
-```
-
-If you are running a simulator and want to capture logs from the console, you can explicitly start log capture yourself.
-```swift
-// Swift
-Critic.instance().startLogCapture()
-```
-
-```objective-c
-// Objective-C
-[[Critic instance] startLogCapture];
-```
-
-## Sending Customer Feedback Reports
-
-You can show the default feedback report screen any time you like by calling the following method from a `UIViewController`.
-```swift
-// Swift
-Critic.instance().showDefaultFeedbackScreen(self)
-```
-
-```objective-c
-// Objective-C
-[[Critic instance] showDefaultFeedbackScreen:self];
-```
-
-### Change Text on Default Feedback Screens.
-
-The text shown on the default feedback report screen and the shake detection dialog can be customized to your liking.
-```swift
-// Swift
-Critic.instance().setDefaultShakeNotificationTitle("Easy, easy!")
-Critic.instance().setDefaultShakeNotificationMessage("Do you want to send us feedback?")
-
-Critic.instance().setDefaultFeedbackScreenTitle("Submit Feedback")
-Critic.instance().setDefaultFeedbackScreenDescriptionPlaceholder("What's happening?\n\nPlease describe your problem or suggestion in as much detail as possible. Thank you for helping us out! 🙂");
-```
-
-```objective-c
-// Objective-C
-[[Critic instance] setDefaultShakeNotificationTitle:@"Easy, easy!"];
-[[Critic instance] setDefaultShakeNotificationMessage:@"Do you want to send us feedback?"];
-
-[[Critic instance] setDefaultFeedbackScreenTitle:@"Submit Feedback"];
-[[Critic instance] setDefaultFeedbackScreenDescriptionPlaceholder:@"What's happening?\n\nPlease describe your problem or suggestion in as much detail as possible. Thank you for helping us out! 🙂"];
-``` 
-
-### Sending Product-Specific Metadata with Reports
-
-You can add product-specific metadata through adding entries to the `Critic.instance().productMetadata` dictionary.
-```swift
-// Swift
-Critic.instance().productMetadata["email"] = "test@example.com"
-```
-
-```objective-c
-// Objective-C
-[[[Critic instance] productMetadata] setObject:@"test@example.com" forKey:@"email"];
-```
-
-### Sending Device-Specific Metadata
-
-You can add device-specific metadata through adding entries to the `Critic.instance().deviceMetadata` dictionary.
-```swift
-// Swift
-Critic.instance().deviceMetadata["device_uuid"] = "abc123"
-```
-
-```objective-c
-// Objective-C
-[[[Critic instance] deviceMetadata] setObject:@"abc123" forKey:@"device_uuid"];
-```
-
-Be sure to set your metadata values prior to calling `Critic.instance().start()` if you wish to include the metadata with every device ping.
-Metdata added after starting will only be added to bug report submissions.
-
-## Customizing Feedback Reports
-
-Use the `NVCReportCreator` to build your own reports for custom user experiences or other use cases. Perform `NVCReportCreator` work on a background thread.
-```swift
-// Swift
-let reportCreator = NVCReportCreator()
-reportCreator.description = "This is user-entered text about the idea or experience they wish to report."
-reportCreator.metadata["Whatever key you want"] = "Whatever value you want"
-reportCreator.attachmentFilePaths.add("/absolute/path/to/desired/file.txt")
-reportCreator.create({(success: Bool, error: Error?) in
-    if success {
-        NSLog("Feedback has been submitted!")
+@main
+struct MyApp: App {
+    init() {
+        Task {
+            try await Critic.shared.initialize(apiToken: "YOUR_API_TOKEN")
+        }
     }
-    else {
-        NSLog("Feedback submission failed.")
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
     }
-})
+}
 ```
 
-```objective-c
-// Objective-C
-NVCReportCreator *reportCreator = [NVCReportCreator new];
-reportCreator.description = @"This is user-entered text about the idea or experience they wish to report.";
-[report.metadata setObject:@"Whatever value you like" forKey:@"Whatever key you want"];
-[report.attachmentFilePaths addObject:@"/absolute/path/to/desired/file.txt"];
-[reportCreator create:^(BOOL success, NSError *error){
-    if(success){
-        NSLog(@"Feedback has been submitted!");
-    } else {
-        NSLog(@"Feedback submission failed.");
+Or in a UIKit `AppDelegate`:
+
+```swift
+import Critic
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        Task {
+            try await Critic.shared.initialize(apiToken: "YOUR_API_TOKEN")
+        }
+        return true
     }
-}];
+}
 ```
 
-## Viewing Feedback Reports
-Visit the [Critic web portal](https://critic.inventiv.io/) to view submitted reports. Below is some of the device and app-specific information included with every iOS report.
+Find your API token in the [Critic Web Portal](https://critic.inventiv.io/products) under your product's details.
 
-![Critic iOS app info as view in the web portal](https://assets.inventiv.io/github/inventiv-critic-ios/critic-ios-app-info.png)
-![Critic iOS device info as view in the web portal](https://assets.inventiv.io/github/inventiv-critic-ios/critic-ios-device-info.png)
+### 2. Submit Feedback
 
-## Library Development
+Submit a bug report programmatically:
 
-The following steps are only necessary if you plan to contribute to this library.
-You do not need to do these steps if you simply wish to use Critic in your app.
+```swift
+let input = BugReportInput(
+    description: "App crashes when tapping the profile button",
+    metadata: ["screen": "profile", "user_tier": "premium"],
+    stepsToReproduce: "1. Open app\n2. Tap Profile\n3. App crashes",
+    userIdentifier: "user@example.com"
+)
 
-### Setup
+do {
+    let report = try await Critic.shared.submitReport(input)
+    print("Report submitted: \(report.id)")
+} catch {
+    print("Failed to submit: \(error)")
+}
+```
+
+### 3. Submit with Attachments
+
+Include screenshots or log files with your report:
+
+```swift
+let screenshotData = try Data(contentsOf: screenshotURL)
+
+let report = try await Critic.shared.submitReport(
+    BugReportInput(description: "UI layout broken on iPad"),
+    attachments: [
+        (filename: "screenshot.png", mimeType: "image/png", data: screenshotData)
+    ]
+)
+```
+
+## Built-in UI
+
+### SwiftUI Feedback View
+
+Present the built-in feedback form in SwiftUI:
+
+```swift
+import Critic
+
+struct ContentView: View {
+    @State private var showFeedback = false
+
+    var body: some View {
+        Button("Send Feedback") {
+            showFeedback = true
+        }
+        .sheet(isPresented: $showFeedback) {
+            FeedbackView(
+                onSubmit: { report in
+                    showFeedback = false
+                    print("Submitted: \(report.id)")
+                },
+                onCancel: {
+                    showFeedback = false
+                },
+                userIdentifier: "user@example.com"
+            )
+        }
+    }
+}
+```
+
+### UIKit Feedback View Controller
+
+Use `FeedbackViewController` in UIKit apps:
+
+```swift
+import Critic
+
+let feedbackVC = FeedbackViewController()
+feedbackVC.userIdentifier = "user@example.com"
+feedbackVC.onSubmit = { report in
+    print("Submitted: \(report.id)")
+}
+feedbackVC.onCancel = {
+    print("Cancelled")
+}
+feedbackVC.modalPresentationStyle = .formSheet
+present(feedbackVC, animated: true)
+```
+
+### Shake to Send Feedback
+
+Enable shake-to-report using `ShakeDetectingWindow`:
+
+```swift
+import Critic
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+    let shakeDetector = ShakeDetector()
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        let window = ShakeDetectingWindow(windowScene: windowScene)
+        window.rootViewController = UINavigationController(rootViewController: YourRootVC())
+        self.window = window
+        window.makeKeyAndVisible()
+
+        shakeDetector.install(on: window)
+    }
+}
+```
+
+## API Client
+
+For advanced use cases, access the API client directly after initialization:
+
+```swift
+guard let api = Critic.shared.api else { return }
+
+// List bug reports
+let reports = try await api.listBugReports(appApiToken: "YOUR_APP_TOKEN")
+for report in reports.items {
+    print("\(report.id): \(report.description ?? "No description")")
+}
+
+// Get a single bug report
+let report = try await api.getBugReport(id: "report-uuid", appApiToken: "YOUR_APP_TOKEN")
+
+// List devices
+let devices = try await api.listDevices(appApiToken: "YOUR_APP_TOKEN")
+```
+
+## Error Handling
+
+All API methods throw `CriticError` on failure:
+
+```swift
+do {
+    let report = try await Critic.shared.submitReport(input)
+} catch CriticError.unauthorized {
+    print("Invalid API token")
+} catch CriticError.forbidden {
+    print("Access forbidden")
+} catch CriticError.notFound {
+    print("Resource not found")
+} catch CriticError.validationFailed(let message) {
+    print("Validation error: \(message)")
+} catch CriticError.badRequest(let message) {
+    print("Bad request: \(message)")
+} catch CriticError.notInitialized {
+    print("SDK not initialized — call Critic.shared.initialize() first")
+} catch CriticError.networkError(let message) {
+    print("Network error: \(message)")
+} catch {
+    print("Unexpected error: \(error)")
+}
+```
+
+## Custom Base URL
+
+Point the SDK to a self-hosted Critic instance:
+
+```swift
+try await Critic.shared.initialize(
+    apiToken: "YOUR_API_TOKEN",
+    baseURL: URL(string: "https://your-critic-instance.example.com")
+)
+```
+
+## Requirements
+
+- iOS 16.0+
+- Swift 6.0+
+- Xcode 16.0+
+
+## Contributing
 
 1. Clone this repository.
-2. Open the workspace in XCode.
-3. Update the `Example` project's `Podfile` to reference the local repository instead of a specific version of the Critic Cocoapod.
-4. Validate everything works in your simulator.
-
-### Releasing a New Cocoapod Version
-
-1. Update the version in `Critic.podspec`.
-2. Create a new tag for your changes, and push it up to GitHub.
-3. Run `bundle exec pod trunk push Critic.podspec`
-4. Wait several minutes for the updated version to become available.
-5. Update your `Podfile` to reference the new version.
-6. Run `bundle exec pod repo update && bundle exec pod install --repo-update` to update to the new version.
+2. Open `Package.swift` in Xcode.
+3. Run tests with `Cmd+U` or `swift test`.
 
 ## License
 
-This library is released under the MIT License.
+This library is released under the [MIT License](LICENSE).

--- a/Sources/Critic/API/CriticAPI.swift
+++ b/Sources/Critic/API/CriticAPI.swift
@@ -1,18 +1,40 @@
 import Foundation
 
 /// Handles communication with the Critic v3 REST API.
+///
+/// `CriticAPI` is an actor that provides type-safe access to all Critic API endpoints.
+/// It is typically accessed through ``Critic/api`` after SDK initialization, but can also
+/// be created directly for custom configurations.
+///
+/// ## Topics
+///
+/// ### Registration
+/// - ``ping(_:)``
+///
+/// ### Bug Reports
+/// - ``createBugReport(report:appInstallId:attachments:deviceStatus:)``
+/// - ``listBugReports(appApiToken:archived:deviceId:since:)``
+/// - ``getBugReport(id:appApiToken:)``
+///
+/// ### Devices
+/// - ``listDevices(appApiToken:)``
 public actor CriticAPI {
 
-    /// The base URL for API requests (e.g. "https://critic.inventiv.io").
+    /// The base URL for API requests (e.g. `https://critic.inventiv.io`).
     public let baseURL: URL
 
-    /// The organization API token for POST endpoints.
+    /// The organization API token used for authenticated POST endpoints.
     public let apiToken: String
 
     private let session: URLSession
     private let decoder: JSONDecoder
 
     /// Creates a new API client.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL of the Critic API server.
+    ///   - apiToken: The organization API token for authentication.
+    ///   - session: The URL session to use for requests. Defaults to `.shared`.
     public init(baseURL: URL, apiToken: String, session: URLSession = .shared) {
         self.baseURL = baseURL
         self.apiToken = apiToken
@@ -23,6 +45,13 @@ public actor CriticAPI {
     // MARK: - Ping
 
     /// Register an app install with the Critic API.
+    ///
+    /// Sends device and app information to the server and receives an app install ID
+    /// that is used for subsequent API calls.
+    ///
+    /// - Parameter request: The ping request containing app, device, and status information.
+    /// - Returns: The ``AppInstall`` with the server-assigned install ID.
+    /// - Throws: ``CriticError`` if the request fails.
     public func ping(_ request: PingRequest) async throws -> AppInstall {
         let url = Endpoints.ping(baseURL: baseURL)
         let body = try JSONEncoder().encode(request)
@@ -39,6 +68,17 @@ public actor CriticAPI {
     // MARK: - Bug Reports
 
     /// Create a bug report with optional file attachments.
+    ///
+    /// Submits a bug report as multipart form data, including optional file attachments
+    /// and device status information.
+    ///
+    /// - Parameters:
+    ///   - report: The bug report input data.
+    ///   - appInstallId: The app install ID from a prior ``ping(_:)`` call.
+    ///   - attachments: Optional file attachments to include with the report.
+    ///   - deviceStatus: Optional device status snapshot at the time of the report.
+    /// - Returns: The created ``BugReport`` as returned by the server.
+    /// - Throws: ``CriticError`` if the request fails.
     public func createBugReport(
         report: BugReportInput,
         appInstallId: String,
@@ -89,6 +129,14 @@ public actor CriticAPI {
     }
 
     /// List bug reports for an app.
+    ///
+    /// - Parameters:
+    ///   - appApiToken: The app-specific API token.
+    ///   - archived: Filter by archived status. Pass `nil` for all reports.
+    ///   - deviceId: Filter by device ID. Pass `nil` for all devices.
+    ///   - since: Filter reports created after this ISO 8601 date string.
+    /// - Returns: A ``PaginatedResponse`` containing ``BugReport`` items.
+    /// - Throws: ``CriticError`` if the request fails.
     public func listBugReports(
         appApiToken: String,
         archived: Bool? = nil,
@@ -117,6 +165,12 @@ public actor CriticAPI {
     }
 
     /// Get a single bug report by ID.
+    ///
+    /// - Parameters:
+    ///   - id: The UUID string of the bug report.
+    ///   - appApiToken: The app-specific API token.
+    /// - Returns: The requested ``BugReport``.
+    /// - Throws: ``CriticError/notFound`` if the report does not exist, or another ``CriticError`` on failure.
     public func getBugReport(id: String, appApiToken: String) async throws -> BugReport {
         var url = Endpoints.bugReport(baseURL: baseURL, id: id)
         url = url.appending(queryItems: [URLQueryItem(name: "app_api_token", value: appApiToken)])
@@ -130,6 +184,10 @@ public actor CriticAPI {
     // MARK: - Devices
 
     /// List devices for an app.
+    ///
+    /// - Parameter appApiToken: The app-specific API token.
+    /// - Returns: A ``PaginatedResponse`` containing ``Device`` items.
+    /// - Throws: ``CriticError`` if the request fails.
     public func listDevices(appApiToken: String) async throws -> PaginatedResponse<Device> {
         var url = Endpoints.devices(baseURL: baseURL)
         url = url.appending(queryItems: [URLQueryItem(name: "app_api_token", value: appApiToken)])

--- a/Sources/Critic/Critic.swift
+++ b/Sources/Critic/Critic.swift
@@ -1,21 +1,53 @@
 import Foundation
 
 /// Primary entry point for the Critic SDK.
+///
+/// Use the ``shared`` singleton to initialize the SDK and submit bug reports.
+///
+/// ## Getting Started
+///
+/// Initialize the SDK early in your app lifecycle:
+///
+/// ```swift
+/// try await Critic.shared.initialize(apiToken: "YOUR_API_TOKEN")
+/// ```
+///
+/// Then submit reports:
+///
+/// ```swift
+/// let input = BugReportInput(description: "Something broke")
+/// let report = try await Critic.shared.submitReport(input)
+/// ```
+///
+/// ## Topics
+///
+/// ### Initialization
+/// - ``initialize(apiToken:baseURL:)``
+///
+/// ### Submitting Reports
+/// - ``submitReport(_:attachments:)``
+///
+/// ### Properties
+/// - ``shared``
+/// - ``api``
+/// - ``appInstallId``
+/// - ``apiToken``
+/// - ``baseURL``
 public final class Critic: @unchecked Sendable {
 
-    /// Shared singleton instance.
+    /// The shared singleton instance of the Critic SDK.
     public static let shared = Critic()
 
-    /// The API client, available after initialization.
+    /// The API client, available after ``initialize(apiToken:baseURL:)`` is called.
     public private(set) var api: CriticAPI?
 
-    /// The app install ID, set after a successful ping.
+    /// The app install ID assigned by the server after a successful ping.
     public private(set) var appInstallId: String?
 
     /// The API token used for this session.
     public private(set) var apiToken: String?
 
-    /// The base URL for the Critic API.
+    /// The base URL for the Critic API. Defaults to `https://critic.inventiv.io`.
     public private(set) var baseURL: URL
 
     private let lock = NSLock()
@@ -30,7 +62,14 @@ public final class Critic: @unchecked Sendable {
     }
 
     /// Initialize the SDK with an organization API token.
-    /// Performs a ping to register the device and app install.
+    ///
+    /// Performs a ping to register the device and app install with the Critic server.
+    /// Must be called before ``submitReport(_:attachments:)``.
+    ///
+    /// - Parameters:
+    ///   - apiToken: Your organization's API token from the Critic web portal.
+    ///   - baseURL: Optional custom base URL for self-hosted instances. Defaults to `https://critic.inventiv.io`.
+    /// - Throws: ``CriticError`` if the ping request fails.
     #if canImport(UIKit)
     @MainActor
     public func initialize(
@@ -81,6 +120,16 @@ public final class Critic: @unchecked Sendable {
     #endif
 
     /// Submit a bug report with optional file attachments.
+    ///
+    /// The SDK must be initialized via ``initialize(apiToken:baseURL:)`` before calling this method.
+    /// Device status (battery, memory, disk) is automatically collected and included with the report.
+    ///
+    /// - Parameters:
+    ///   - report: The bug report input containing description, metadata, and other fields.
+    ///   - attachments: Optional array of file attachments (filename, MIME type, and data).
+    /// - Returns: The created ``BugReport`` as returned by the server.
+    /// - Throws: ``CriticError/notInitialized`` if the SDK has not been initialized,
+    ///   or another ``CriticError`` if the request fails.
     public func submitReport(
         _ report: BugReportInput,
         attachments: [(filename: String, mimeType: String, data: Data)]? = nil

--- a/Sources/Critic/Models/CriticError.swift
+++ b/Sources/Critic/Models/CriticError.swift
@@ -1,6 +1,19 @@
 import Foundation
 
 /// Errors that can occur when interacting with the Critic SDK.
+///
+/// These errors map to specific HTTP status codes returned by the Critic API,
+/// as well as client-side conditions like network failures and decoding errors.
+///
+/// ```swift
+/// do {
+///     let report = try await Critic.shared.submitReport(input)
+/// } catch CriticError.unauthorized {
+///     // Handle invalid API token
+/// } catch CriticError.notInitialized {
+///     // SDK was not initialized
+/// }
+/// ```
 public enum CriticError: Error, Sendable, Equatable {
 
     /// The API token is invalid (HTTP 401).

--- a/Tests/CriticTests/CriticAPITests.swift
+++ b/Tests/CriticTests/CriticAPITests.swift
@@ -1,0 +1,559 @@
+import Testing
+import Foundation
+@testable import Critic
+
+// MARK: - Mock URLProtocol
+
+/// A URLProtocol subclass that intercepts network requests for testing.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    /// Handler that provides (response, data, error) for each request.
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    /// Captured requests for assertion.
+    nonisolated(unsafe) static var capturedRequests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedRequests.append(request)
+
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        requestHandler = nil
+        capturedRequests = []
+    }
+}
+
+/// Creates a URLSession configured with MockURLProtocol.
+private func mockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+/// Creates a CriticAPI instance using the mock session.
+private func mockAPI(baseURL: String = "https://critic.test.io", apiToken: String = "test-token") -> CriticAPI {
+    CriticAPI(baseURL: URL(string: baseURL)!, apiToken: apiToken, session: mockSession())
+}
+
+// MARK: - Ping Request Construction Tests
+
+@Test func pingRequestSendsCorrectHTTPMethod() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let body = Data("""
+        {"app_install": {"id": "install-123"}}
+        """.utf8)
+        return (response, body)
+    }
+
+    let api = mockAPI()
+    let pingRequest = PingRequest(
+        apiToken: "test-token",
+        app: AppInfo(name: "App", package: "com.test", version: AppVersionInfo(code: "1", name: "1.0")),
+        device: DeviceInfoData(identifier: "dev-id", manufacturer: "Apple", model: "iPhone15,2", networkCarrier: "Verizon", platformVersion: "17.0")
+    )
+
+    _ = try await api.ping(pingRequest)
+
+    let captured = MockURLProtocol.capturedRequests.first
+    #expect(captured?.httpMethod == "POST")
+    #expect(captured?.url?.absoluteString == "https://critic.test.io/api/v3/ping")
+    #expect(captured?.value(forHTTPHeaderField: "Content-Type") == "application/json")
+}
+
+@Test func pingRequestBodyContainsCorrectFields() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"app_install": {"id": "install-456"}}
+        """.utf8))
+    }
+
+    let api = mockAPI(apiToken: "org-token-abc")
+    let pingRequest = PingRequest(
+        apiToken: "org-token-abc",
+        app: AppInfo(name: "MyApp", package: "com.myapp", version: AppVersionInfo(code: "42", name: "2.1.0")),
+        device: DeviceInfoData(identifier: "dev-xyz", manufacturer: "Apple", model: "iPad14,1", networkCarrier: "AT&T", platformVersion: "16.5")
+    )
+
+    _ = try await api.ping(pingRequest)
+
+    let captured = MockURLProtocol.capturedRequests.first
+    let bodyData = captured?.httpBody ?? Data()
+    let body = try JSONSerialization.jsonObject(with: bodyData) as! [String: Any]
+
+    #expect(body["api_token"] as? String == "org-token-abc")
+    let app = body["app"] as! [String: Any]
+    #expect(app["name"] as? String == "MyApp")
+    #expect(app["package"] as? String == "com.myapp")
+    let version = app["version"] as! [String: Any]
+    #expect(version["code"] as? String == "42")
+}
+
+@Test func pingResponseParsesAppInstallId() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"app_install": {"id": "uuid-parsed-correctly"}}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let result = try await api.ping(PingRequest(
+        apiToken: "t",
+        app: AppInfo(name: "A", package: "p", version: AppVersionInfo(code: "1", name: "1")),
+        device: DeviceInfoData(identifier: "i", manufacturer: "Apple", model: "m", networkCarrier: "c", platformVersion: "v")
+    ))
+
+    #expect(result.id == "uuid-parsed-correctly")
+}
+
+// MARK: - Bug Report Request Construction Tests
+
+@Test func createBugReportSendsMultipartPOST() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"id": "br-new", "description": "Test bug"}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let input = BugReportInput(description: "Test bug", metadata: ["env": "staging"], stepsToReproduce: "1. Open app", userIdentifier: "user@test.com")
+
+    _ = try await api.createBugReport(report: input, appInstallId: "install-id")
+
+    let captured = MockURLProtocol.capturedRequests.first
+    #expect(captured?.httpMethod == "POST")
+    #expect(captured?.url?.absoluteString == "https://critic.test.io/api/v3/bug_reports")
+    let contentType = captured?.value(forHTTPHeaderField: "Content-Type") ?? ""
+    #expect(contentType.hasPrefix("multipart/form-data; boundary="))
+
+    let bodyString = String(data: captured?.httpBody ?? Data(), encoding: .utf8) ?? ""
+    #expect(bodyString.contains("name=\"api_token\""))
+    #expect(bodyString.contains("test-token"))
+    #expect(bodyString.contains("name=\"app_install[id]\""))
+    #expect(bodyString.contains("install-id"))
+    #expect(bodyString.contains("name=\"bug_report[description]\""))
+    #expect(bodyString.contains("Test bug"))
+    #expect(bodyString.contains("name=\"bug_report[steps_to_reproduce]\""))
+    #expect(bodyString.contains("1. Open app"))
+    #expect(bodyString.contains("name=\"bug_report[user_identifier]\""))
+    #expect(bodyString.contains("user@test.com"))
+    #expect(bodyString.contains("name=\"bug_report[metadata]\""))
+}
+
+@Test func createBugReportWithAttachments() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"id": "br-attach"}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let input = BugReportInput(description: "With file")
+    let fileData = Data("screenshot content".utf8)
+
+    _ = try await api.createBugReport(
+        report: input,
+        appInstallId: "inst-1",
+        attachments: [(filename: "screenshot.png", mimeType: "image/png", data: fileData)]
+    )
+
+    let bodyString = String(data: MockURLProtocol.capturedRequests.first?.httpBody ?? Data(), encoding: .utf8) ?? ""
+    #expect(bodyString.contains("name=\"bug_report[attachments][]\""))
+    #expect(bodyString.contains("filename=\"screenshot.png\""))
+    #expect(bodyString.contains("Content-Type: image/png"))
+    #expect(bodyString.contains("screenshot content"))
+}
+
+@Test func createBugReportParsesResponse() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {
+            "id": "br-full",
+            "description": "Full report",
+            "steps_to_reproduce": "Step 1",
+            "user_identifier": "jane@example.com",
+            "created_at": "2026-03-27T10:00:00Z",
+            "device": {"id": "dev-1", "model": "iPhone15,2"},
+            "attachments": [{"id": "att-1", "file_file_name": "log.txt"}]
+        }
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let result = try await api.createBugReport(report: BugReportInput(description: "Full report"), appInstallId: "inst")
+
+    #expect(result.id == "br-full")
+    #expect(result.description == "Full report")
+    #expect(result.stepsToReproduce == "Step 1")
+    #expect(result.userIdentifier == "jane@example.com")
+    #expect(result.device?.model == "iPhone15,2")
+    #expect(result.attachments?.first?.fileFileName == "log.txt")
+}
+
+// MARK: - List Bug Reports Tests
+
+@Test func listBugReportsRequestConstruction() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"count": 0, "current_page": 1, "total_pages": 0, "bug_reports": []}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    _ = try await api.listBugReports(appApiToken: "app-tok", archived: true, deviceId: "dev-1", since: "2026-01-01")
+
+    let captured = MockURLProtocol.capturedRequests.first
+    #expect(captured?.httpMethod == "GET")
+    let urlString = captured?.url?.absoluteString ?? ""
+    #expect(urlString.contains("app_api_token=app-tok"))
+    #expect(urlString.contains("archived=true"))
+    #expect(urlString.contains("device_id=dev-1"))
+    #expect(urlString.contains("since=2026-01-01"))
+}
+
+@Test func listBugReportsParsesPaginatedResponse() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {
+            "count": 2,
+            "current_page": 1,
+            "total_pages": 1,
+            "bug_reports": [
+                {"id": "br-1", "description": "First"},
+                {"id": "br-2", "description": "Second"}
+            ]
+        }
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let result = try await api.listBugReports(appApiToken: "tok")
+
+    #expect(result.count == 2)
+    #expect(result.currentPage == 1)
+    #expect(result.totalPages == 1)
+    #expect(result.items.count == 2)
+    #expect(result.items[0].id == "br-1")
+    #expect(result.items[1].description == "Second")
+}
+
+// MARK: - Get Bug Report Tests
+
+@Test func getBugReportRequestConstruction() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"id": "br-uuid-123", "description": "Single report"}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let result = try await api.getBugReport(id: "br-uuid-123", appApiToken: "app-tok")
+
+    let captured = MockURLProtocol.capturedRequests.first
+    #expect(captured?.httpMethod == "GET")
+    #expect(captured?.url?.absoluteString.contains("bug_reports/br-uuid-123") == true)
+    #expect(captured?.url?.absoluteString.contains("app_api_token=app-tok") == true)
+    #expect(result.id == "br-uuid-123")
+    #expect(result.description == "Single report")
+}
+
+// MARK: - List Devices Tests
+
+@Test func listDevicesRequestConstruction() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {
+            "count": 1,
+            "current_page": 1,
+            "total_pages": 1,
+            "devices": [{"id": "dev-1", "model": "iPhone15,2", "platform": "iOS"}]
+        }
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let result = try await api.listDevices(appApiToken: "app-tok")
+
+    let captured = MockURLProtocol.capturedRequests.first
+    #expect(captured?.httpMethod == "GET")
+    #expect(captured?.url?.absoluteString.contains("devices") == true)
+    #expect(captured?.url?.absoluteString.contains("app_api_token=app-tok") == true)
+    #expect(result.items.count == 1)
+    #expect(result.items[0].model == "iPhone15,2")
+}
+
+// MARK: - Error Handling Tests (HTTP Status Codes)
+
+@Test func apiReturns401Unauthorized() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+        return (response, Data("Unauthorized".utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.listBugReports(appApiToken: "bad-token")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .unauthorized)
+    }
+}
+
+@Test func apiReturns403Forbidden() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+        return (response, Data("Forbidden".utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.listBugReports(appApiToken: "tok")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .forbidden)
+    }
+}
+
+@Test func apiReturns404NotFound() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+        return (response, Data("Not Found".utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.getBugReport(id: "nonexistent", appApiToken: "tok")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .notFound)
+    }
+}
+
+@Test func apiReturns422ValidationFailed() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 422, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"error": "Description is required"}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.createBugReport(report: BugReportInput(description: ""), appInstallId: "inst")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .validationFailed("Description is required"))
+    }
+}
+
+@Test func apiReturns400BadRequest() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        ["Invalid api_token parameter"]
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.createBugReport(report: BugReportInput(description: "test"), appInstallId: "inst")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .badRequest("Invalid api_token parameter"))
+    }
+}
+
+@Test func apiReturns500UnexpectedStatusCode() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+        return (response, Data("Internal Server Error".utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.listDevices(appApiToken: "tok")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .unexpectedStatusCode(500))
+    }
+}
+
+@Test func apiReturnsInvalidJSONThrowsDecodingFailed() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("not valid json {{{".utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.listBugReports(appApiToken: "tok")
+        #expect(Bool(false), "Should have thrown")
+    } catch let error as CriticError {
+        #expect(error == .decodingFailed)
+    }
+}
+
+// MARK: - UUID String Handling Tests
+
+@Test func modelIdsAreDecodedAsStrings() throws {
+    // All IDs come as UUID strings from the API; verify they're handled correctly
+    let json = """
+    {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "description": "UUID test",
+        "device": {"id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "model": "iPhone"},
+        "app": {"id": "f47ac10b-58cc-4372-a567-0e02b2c3d479", "name": "TestApp"},
+        "attachments": [{"id": "a9b1c2d3-e4f5-6789-abcd-ef0123456789"}]
+    }
+    """
+    let report = try JSONDecoder().decode(BugReport.self, from: Data(json.utf8))
+    #expect(report.id == "550e8400-e29b-41d4-a716-446655440000")
+    #expect(report.device?.id == "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+    #expect(report.app?.id == "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    #expect(report.attachments?.first?.id == "a9b1c2d3-e4f5-6789-abcd-ef0123456789")
+}
+
+@Test func appInstallIdIsUUIDString() throws {
+    let json = """
+    {"id": "c56a4180-65aa-42ec-a945-5fd21dec0538"}
+    """
+    let install = try JSONDecoder().decode(AppInstall.self, from: Data(json.utf8))
+    #expect(install.id == "c56a4180-65aa-42ec-a945-5fd21dec0538")
+}
+
+@Test func nonStandardIdFormatsDecodeCorrectly() throws {
+    // The API may return non-UUID string IDs in some cases
+    let json = """
+    {"id": "simple-string-id", "name": "Test"}
+    """
+    let app = try JSONDecoder().decode(App.self, from: Data(json.utf8))
+    #expect(app.id == "simple-string-id")
+}
+
+// MARK: - Device Status Fields in Bug Report Request
+
+@Test func createBugReportIncludesDeviceStatus() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"id": "br-ds"}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    let status = DeviceStatus(batteryCharging: true, batteryLevel: 85, diskFree: 1_000_000, memoryTotal: 8_000_000)
+
+    _ = try await api.createBugReport(
+        report: BugReportInput(description: "With status"),
+        appInstallId: "inst",
+        deviceStatus: status
+    )
+
+    let bodyString = String(data: MockURLProtocol.capturedRequests.first?.httpBody ?? Data(), encoding: .utf8) ?? ""
+    #expect(bodyString.contains("device_status[battery_charging]"))
+    #expect(bodyString.contains("true"))
+    #expect(bodyString.contains("device_status[battery_level]"))
+    #expect(bodyString.contains("85"))
+    #expect(bodyString.contains("device_status[disk_free]"))
+    #expect(bodyString.contains("device_status[memory_total]"))
+}
+
+// MARK: - Error Message Extraction Tests
+
+@Test func errorMessageFromJsonDict() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 422, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        {"error": "Validation failed: description can't be blank"}
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.createBugReport(report: BugReportInput(description: ""), appInstallId: "inst")
+        #expect(Bool(false))
+    } catch let error as CriticError {
+        #expect(error == .validationFailed("Validation failed: description can't be blank"))
+    }
+}
+
+@Test func errorMessageFromJsonArray() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+        return (response, Data("""
+        ["First error message", "Second error"]
+        """.utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.createBugReport(report: BugReportInput(description: "test"), appInstallId: "inst")
+        #expect(Bool(false))
+    } catch let error as CriticError {
+        #expect(error == .badRequest("First error message"))
+    }
+}
+
+@Test func errorMessageFromPlainText() async throws {
+    MockURLProtocol.reset()
+    MockURLProtocol.requestHandler = { _ in
+        let response = HTTPURLResponse(url: URL(string: "https://critic.test.io")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+        return (response, Data("Plain text error".utf8))
+    }
+
+    let api = mockAPI()
+    do {
+        _ = try await api.createBugReport(report: BugReportInput(description: "test"), appInstallId: "inst")
+        #expect(Bool(false))
+    } catch let error as CriticError {
+        #expect(error == .badRequest("Plain text error"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive mock URLProtocol tests for API request construction, response parsing, and error handling (401, 403, 404, 422, 400, 500)
- Add UUID string handling and model encoding/decoding tests
- Rewrite README with modern Swift usage examples for both SPM and CocoaPods
- Add DocC documentation comments on all public API surfaces
- Add GitHub Actions CI with build + test matrix (Xcode 16.0, 16.2)
- Create SPM-compatible example project
- Version at 1.0.0 — not tagged, not published

## Test plan
- [ ] CI build-and-test matrix passes on Xcode 16.0 and 16.2
- [ ] Pod lint passes
- [ ] All new mock URLProtocol tests pass
- [ ] Existing unit tests still pass
- [ ] SPM example resolves and builds against the local package
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)