### PR TITLE
fix: remove misleading env var references from example app

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -5,7 +5,7 @@ A minimal SwiftUI app demonstrating the Critic iOS SDK.
 ## Running the Example
 
 1. Open `Package.swift` in Xcode.
-2. Replace `"YOUR_API_TOKEN"` in `CriticExampleApp.swift` with your API token from the [Critic Web Portal](https://critic.inventiv.io/products).
+2. Set `apiToken` in `CriticExampleApp.swift` to your API token from the [Critic Web Portal](https://critic.inventiv.io/products).
 3. Select an iOS Simulator and run.
 
 ### Local Development

--- a/Example/Sources/CriticExampleApp.swift
+++ b/Example/Sources/CriticExampleApp.swift
@@ -5,12 +5,12 @@ import Critic
 @main
 struct CriticExampleApp: SwiftUI.App {
     /// Configure before running locally: set to your Critic server URL for development,
-    /// or leave nil for production. You can also set the CRITIC_BASE_URL environment variable.
+    /// or leave nil for production.
     /// Example: URL(string: "http://localhost:8000")
     private static let customBaseURL: URL? = nil
 
     /// Configure before running locally: replace with your API token from
-    /// https://critic.inventiv.io/products, or set the CRITIC_API_TOKEN environment variable.
+    /// https://critic.inventiv.io/products.
     private static let apiToken = ""
 
     init() {


### PR DESCRIPTION
## Summary
- Remove misleading `CRITIC_BASE_URL` / `CRITIC_API_TOKEN` environment variable references from example app comments — the SDK does not read env vars; only integration tests do
- Update README step 2 to match current code where `apiToken` is an empty string rather than the `"YOUR_API_TOKEN"` placeholder literal

## Context
Part of CRITIC-189: iOS example app fixes, test fixes, and SwiftUI.App type disambiguation. The base branch `chore/example-app-and-testing` already contains the core changes (SwiftUI.App disambiguation, `@Suite(.serialized)` test fix, `httpBodyStream` capture, conditionally-enabled integration tests). This PR fixes documentation inaccuracies in the example app.

## Test plan
- [ ] Verify `swift build` passes
- [ ] Verify all unit tests pass (`swift test`)
- [ ] Verify integration tests skip without env vars
- [ ] Verify example app builds on iOS simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)