### PR TITLE
CRITIC-192: Collect additional memory details and network status

### DIFF
--- a/Sources/Critic/Utilities/DeviceInfo.swift
+++ b/Sources/Critic/Utilities/DeviceInfo.swift
@@ -2,7 +2,7 @@
 import UIKit
 #endif
 import Foundation
-import Network
+import SystemConfiguration
 
 /// Collects device information using native iOS APIs.
 public struct DeviceInfo: Sendable {
@@ -132,28 +132,30 @@ public struct DeviceInfo: Sendable {
         return (nil, nil, nil, nil, total, nil)
     }
 
-    /// Returns network connectivity status using NWPathMonitor.
+    /// Returns network connectivity status using SCNetworkReachability (synchronous, non-blocking).
     private func networkStatus() -> (wifiConnected: Bool?, cellConnected: Bool?) {
-        let monitor = NWPathMonitor()
-        let semaphore = DispatchSemaphore(value: 0)
-        var capturedPath: NWPath?
+        var zeroAddress = sockaddr()
+        zeroAddress.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zeroAddress.sa_family = sa_family_t(AF_INET)
 
-        monitor.pathUpdateHandler = { path in
-            capturedPath = path
-            semaphore.signal()
-        }
-
-        let queue = DispatchQueue(label: "io.inventiv.critic.network-status")
-        monitor.start(queue: queue)
-        _ = semaphore.wait(timeout: .now() + 1.0)
-        monitor.cancel()
-
-        guard let path = capturedPath else {
+        guard let reachability = SCNetworkReachabilityCreateWithAddress(nil, &zeroAddress) else {
             return (nil, nil)
         }
 
-        let wifiConnected = path.status == .satisfied && path.usesInterfaceType(.wifi)
-        let cellConnected = path.status == .satisfied && path.usesInterfaceType(.cellular)
+        var flags: SCNetworkReachabilityFlags = []
+        guard SCNetworkReachabilityGetFlags(reachability, &flags) else {
+            return (nil, nil)
+        }
+
+        let isReachable = flags.contains(.reachable)
+        #if os(iOS)
+        let isCellular = flags.contains(.isWWAN)
+        #else
+        let isCellular = false
+        #endif
+
+        let wifiConnected = isReachable && !isCellular
+        let cellConnected = isReachable && isCellular
         return (wifiConnected, cellConnected)
     }
 }

--- a/Sources/Critic/Utilities/DeviceInfo.swift
+++ b/Sources/Critic/Utilities/DeviceInfo.swift
@@ -2,6 +2,7 @@
 import UIKit
 #endif
 import Foundation
+import Network
 
 /// Collects device information using native iOS APIs.
 public struct DeviceInfo: Sendable {
@@ -43,6 +44,7 @@ public struct DeviceInfo: Sendable {
 
         let diskInfo = diskSpace()
         let memoryInfo = memoryStatus()
+        let networkInfo = networkStatus()
 
         return DeviceStatus(
             batteryCharging: batteryCharging,
@@ -52,15 +54,15 @@ public struct DeviceInfo: Sendable {
             diskPlatform: nil,
             diskTotal: diskInfo.total,
             diskUsable: diskInfo.free,
-            memoryActive: nil,
+            memoryActive: memoryInfo.active,
             memoryFree: memoryInfo.free,
-            memoryInactive: nil,
-            memoryPurgable: nil,
+            memoryInactive: memoryInfo.inactive,
+            memoryPurgable: memoryInfo.purgable,
             memoryTotal: memoryInfo.total,
-            memoryWired: nil,
-            networkCellConnected: nil,
+            memoryWired: memoryInfo.wired,
+            networkCellConnected: networkInfo.cellConnected,
             networkCellSignalBars: nil,
-            networkWifiConnected: nil,
+            networkWifiConnected: networkInfo.wifiConnected,
             networkWifiSignalBars: nil
         )
     }
@@ -103,10 +105,9 @@ public struct DeviceInfo: Sendable {
         return (free, total)
     }
 
-    /// Returns memory usage information.
-    private func memoryStatus() -> (free: Int64?, total: Int64?) {
+    /// Returns memory usage information including active, inactive, wired, purgeable, free, and total.
+    private func memoryStatus() -> (active: Int64?, free: Int64?, inactive: Int64?, purgable: Int64?, total: Int64?, wired: Int64?) {
         let total = Int64(ProcessInfo.processInfo.physicalMemory)
-        // Approximate free memory using available memory
         var pageSize: vm_size_t = 0
         host_page_size(mach_host_self(), &pageSize)
 
@@ -120,9 +121,39 @@ public struct DeviceInfo: Sendable {
         }
 
         if result == KERN_SUCCESS {
-            let free = Int64(stats.free_count) * Int64(pageSize)
-            return (free, total)
+            let page = Int64(pageSize)
+            let active = Int64(stats.active_count) * page
+            let free = Int64(stats.free_count) * page
+            let inactive = Int64(stats.inactive_count) * page
+            let purgable = Int64(stats.purgeable_count) * page
+            let wired = Int64(stats.wire_count) * page
+            return (active, free, inactive, purgable, total, wired)
         }
-        return (nil, total)
+        return (nil, nil, nil, nil, total, nil)
+    }
+
+    /// Returns network connectivity status using NWPathMonitor.
+    private func networkStatus() -> (wifiConnected: Bool?, cellConnected: Bool?) {
+        let monitor = NWPathMonitor()
+        let semaphore = DispatchSemaphore(value: 0)
+        var capturedPath: NWPath?
+
+        monitor.pathUpdateHandler = { path in
+            capturedPath = path
+            semaphore.signal()
+        }
+
+        let queue = DispatchQueue(label: "io.inventiv.critic.network-status")
+        monitor.start(queue: queue)
+        _ = semaphore.wait(timeout: .now() + 1.0)
+        monitor.cancel()
+
+        guard let path = capturedPath else {
+            return (nil, nil)
+        }
+
+        let wifiConnected = path.status == .satisfied && path.usesInterfaceType(.wifi)
+        let cellConnected = path.status == .satisfied && path.usesInterfaceType(.cellular)
+        return (wifiConnected, cellConnected)
     }
 }

--- a/Tests/CriticTests/CriticTests.swift
+++ b/Tests/CriticTests/CriticTests.swift
@@ -405,6 +405,86 @@ import Foundation
     #expect(input.userIdentifier == nil)
 }
 
+// MARK: - DeviceStatus Additional Fields Tests
+
+@Test func deviceStatusMemoryFieldsDecoding() throws {
+    let json = """
+    {
+        "memory_active": 2147483648,
+        "memory_inactive": 1073741824,
+        "memory_wired": 268435456,
+        "memory_purgable": 536870912,
+        "memory_free": 134217728,
+        "memory_total": 8589934592
+    }
+    """
+    let status = try JSONDecoder().decode(DeviceStatus.self, from: Data(json.utf8))
+    #expect(status.memoryActive == 2_147_483_648)
+    #expect(status.memoryInactive == 1_073_741_824)
+    #expect(status.memoryWired == 268_435_456)
+    #expect(status.memoryPurgable == 536_870_912)
+    #expect(status.memoryFree == 134_217_728)
+    #expect(status.memoryTotal == 8_589_934_592)
+}
+
+@Test func deviceStatusNetworkFieldsDecoding() throws {
+    let json = """
+    {
+        "network_wifi_connected": true,
+        "network_cell_connected": false
+    }
+    """
+    let status = try JSONDecoder().decode(DeviceStatus.self, from: Data(json.utf8))
+    #expect(status.networkWifiConnected == true)
+    #expect(status.networkCellConnected == false)
+}
+
+@Test func deviceStatusMemoryFieldsRoundTrip() throws {
+    let original = DeviceStatus(
+        memoryActive: 2_147_483_648,
+        memoryFree: 134_217_728,
+        memoryInactive: 1_073_741_824,
+        memoryPurgable: 536_870_912,
+        memoryTotal: 8_589_934_592,
+        memoryWired: 268_435_456
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(DeviceStatus.self, from: data)
+    #expect(decoded.memoryActive == original.memoryActive)
+    #expect(decoded.memoryInactive == original.memoryInactive)
+    #expect(decoded.memoryWired == original.memoryWired)
+    #expect(decoded.memoryPurgable == original.memoryPurgable)
+    #expect(decoded.memoryFree == original.memoryFree)
+    #expect(decoded.memoryTotal == original.memoryTotal)
+}
+
+@Test func deviceStatusNetworkFieldsRoundTrip() throws {
+    let original = DeviceStatus(networkCellConnected: false, networkWifiConnected: true)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(DeviceStatus.self, from: data)
+    #expect(decoded.networkWifiConnected == original.networkWifiConnected)
+    #expect(decoded.networkCellConnected == original.networkCellConnected)
+}
+
+@Test func deviceStatusMemoryFieldsNilWhenAbsent() throws {
+    let json = """
+    {"memory_total": 8589934592}
+    """
+    let status = try JSONDecoder().decode(DeviceStatus.self, from: Data(json.utf8))
+    #expect(status.memoryTotal == 8_589_934_592)
+    #expect(status.memoryActive == nil)
+    #expect(status.memoryInactive == nil)
+    #expect(status.memoryWired == nil)
+    #expect(status.memoryPurgable == nil)
+}
+
+@Test func deviceStatusNetworkFieldsNilWhenAbsent() throws {
+    let json = "{}"
+    let status = try JSONDecoder().decode(DeviceStatus.self, from: Data(json.utf8))
+    #expect(status.networkWifiConnected == nil)
+    #expect(status.networkCellConnected == nil)
+}
+
 // MARK: - Round-trip Encoding/Decoding Tests
 
 @Test func deviceStatusRoundTrip() throws {


### PR DESCRIPTION
## Summary

- Expands `memoryStatus()` to return `active`, `inactive`, `wired`, and `purgeable` memory counts from `host_statistics64()` via `vm_statistics64` (no entitlements needed)
- Adds `networkStatus()` using `NWPathMonitor` to detect WiFi and cellular connectivity (no entitlements needed)
- Populates all six new fields (`memoryActive`, `memoryInactive`, `memoryWired`, `memoryPurgable`, `networkWifiConnected`, `networkCellConnected`) in `collectDeviceStatus()`
- Skips `network_wifi_signal_bars`, `network_cell_signal_bars` (require CoreTelephony entitlements), `battery_health` (private API), and `disk_platform` (not meaningful on iOS) per ticket spec

## Test plan

- [ ] `deviceStatusMemoryFieldsDecoding` — verify all memory fields decode from JSON
- [ ] `deviceStatusNetworkFieldsDecoding` — verify wifi/cell connected decode from JSON
- [ ] `deviceStatusMemoryFieldsRoundTrip` — encode then decode preserves all memory values
- [ ] `deviceStatusNetworkFieldsRoundTrip` — encode then decode preserves network values
- [ ] `deviceStatusMemoryFieldsNilWhenAbsent` — absent memory fields decode as nil
- [ ] `deviceStatusNetworkFieldsNilWhenAbsent` — absent network fields decode as nil
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)