### PR TITLE
iOS: Fix nightly security workflow naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Nightly Security
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Renames the CI workflow from `name: CI` to `name: Nightly Security` in `.github/workflows/ci.yml`
- Enables Scarif's automatic security remediation to pick up failures from this workflow

## Test plan
- [ ] Verify the workflow appears as "Nightly Security" in GitHub Actions
- [ ] Confirm nightly schedule jobs (CocoaPods age check and GitHub Actions security check) still run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)