### PR TITLE
Add package age check to PR workflow with quarantine allowlist

### DIFF
--- a/.github/quarantine-allowlist.yml
+++ b/.github/quarantine-allowlist.yml
@@ -1,0 +1,22 @@
+# Quarantine Allowlist
+#
+# Packages listed here bypass the 7-day quarantine age check.
+# Each entry MUST include a reason and an expiration date.
+# Expired entries are ignored (treated as if not listed).
+# Review and remove entries regularly.
+#
+# Format:
+#   packages:
+#     - name: "package-name"       # Package name as it appears in the lockfile
+#       version: "1.2.3"           # Exact version being allowlisted
+#       reason: "Why this is OK"   # Brief explanation
+#       expires: "2026-04-15"      # ISO date; entry ignored after this date
+#
+# Example:
+#   packages:
+#     - name: "Alamofire"
+#       version: "5.9.1"
+#       reason: "Critical security patch for TLS handling"
+#       expires: "2026-04-15"
+
+packages: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
   package-age-check:
     name: CocoaPods Dependency Age Check
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
@@ -68,6 +68,25 @@ jobs:
           QUARANTINE_DAYS=7
           NOW=$(date +%s)
           FAILED=0
+
+          # --- Load quarantine allowlist ---
+          ALLOWLIST_FILE=".github/quarantine-allowlist.yml"
+          is_allowlisted() {
+            local pkg="$1" ver="$2"
+            if [ ! -f "$ALLOWLIST_FILE" ]; then return 1; fi
+            python3 -c "
+          import yaml, sys, datetime
+          with open('$ALLOWLIST_FILE') as f:
+              data = yaml.safe_load(f) or {}
+          for entry in data.get('packages', []):
+              exp = entry.get('expires') or ''
+              if isinstance(exp, datetime.date):
+                  exp = exp.isoformat()
+              if entry.get('name') == sys.argv[1] and entry.get('version') == sys.argv[2] and exp >= datetime.date.today().isoformat():
+                  sys.exit(0)
+          sys.exit(1)
+          " "$pkg" "$ver" 2>/dev/null
+          }
 
           # Extract CocoaPods dependencies with version constraints from the podspec
           # Format: s.dependency 'PodName', '~> 1.2.3'
@@ -116,6 +135,12 @@ jobs:
             fi
 
             RESOLVED_VER=$(echo "$RESOLVED" | cut -d'|' -f1)
+
+            if is_allowlisted "$POD_NAME" "$RESOLVED_VER"; then
+              echo "  ⊘ ALLOWLISTED: $POD_NAME@$RESOLVED_VER (skipping age check)"
+              continue
+            fi
+
             CREATED_AT=$(echo "$RESOLVED" | cut -d'|' -f2)
 
             if [ -z "$CREATED_AT" ] || [ "$CREATED_AT" = "null" ]; then


### PR DESCRIPTION
## Summary
- Run the CocoaPods dependency age check on `pull_request` events (not just nightly schedule)
- Add `.github/quarantine-allowlist.yml` with documented YAML format for bypassing the 7-day quarantine on specific package versions with expiration dates
- Age check script parses the allowlist and logs allowlisted packages as skipped

## Test plan
- [ ] Open a PR and verify the `package-age-check` job runs
- [ ] Add a test entry to `quarantine-allowlist.yml` and verify it is logged as "ALLOWLISTED"
- [ ] Verify expired entries are not honored
- [ ] Verify missing allowlist file does not break the check

Refs: CRITIC-234

🤖 Generated with [Claude Code](https://claude.com/claude-code)