### PR TITLE
CRITIC-235: Rename App model to CriticApp to fix SwiftUI.App collision

### DIFF
--- a/Sources/Critic/Models/BugReport.swift
+++ b/Sources/Critic/Models/BugReport.swift
@@ -34,7 +34,7 @@ public struct BugReport: Codable, Sendable, Equatable {
     public let appVersion: AppVersion?
 
     /// The app associated with the report.
-    public let app: App?
+    public let app: CriticApp?
 
     /// File attachments on the report.
     public let attachments: [Attachment]?
@@ -65,7 +65,7 @@ public struct BugReport: Codable, Sendable, Equatable {
         device: Device? = nil,
         deviceStatus: DeviceStatus? = nil,
         appVersion: AppVersion? = nil,
-        app: App? = nil,
+        app: CriticApp? = nil,
         attachments: [Attachment]? = nil
     ) {
         self.id = id

--- a/Sources/Critic/Models/CriticApp.swift
+++ b/Sources/Critic/Models/CriticApp.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents an application registered with Critic.
-public struct App: Codable, Sendable, Equatable {
+public struct CriticApp: Codable, Sendable, Equatable {
 
     /// The unique identifier (UUID) for this app.
     public let id: String

--- a/Tests/CriticTests/CriticAPITests.swift
+++ b/Tests/CriticTests/CriticAPITests.swift
@@ -371,7 +371,7 @@ private func mockAPI(baseURL: String = "https://critic.test.io", apiToken: Strin
     let json = """
     {"id": "simple-string-id", "name": "Test"}
     """
-    let app = try JSONDecoder().decode(App.self, from: Data(json.utf8))
+    let app = try JSONDecoder().decode(CriticApp.self, from: Data(json.utf8))
     #expect(app.id == "simple-string-id")
 }
 

--- a/Tests/CriticTests/CriticTests.swift
+++ b/Tests/CriticTests/CriticTests.swift
@@ -8,7 +8,7 @@ import Foundation
     let json = """
     {"id": "abc-123", "name": "TestApp", "platform": "iOS"}
     """
-    let app = try JSONDecoder().decode(App.self, from: Data(json.utf8))
+    let app = try JSONDecoder().decode(CriticApp.self, from: Data(json.utf8))
     #expect(app.id == "abc-123")
     #expect(app.name == "TestApp")
     #expect(app.platform == "iOS")
@@ -18,7 +18,7 @@ import Foundation
     let json = """
     {"id": "abc-123"}
     """
-    let app = try JSONDecoder().decode(App.self, from: Data(json.utf8))
+    let app = try JSONDecoder().decode(CriticApp.self, from: Data(json.utf8))
     #expect(app.id == "abc-123")
     #expect(app.name == nil)
     #expect(app.platform == nil)


### PR DESCRIPTION
## Summary

- Renames `public struct App` to `public struct CriticApp` in `Sources/Critic/Models/App.swift` (file renamed to `CriticApp.swift`)
- Updates `BugReport.swift` to use `CriticApp` for the `app` property type
- Updates test files to decode `CriticApp.self` instead of `App.self`

## Motivation

The SDK exported `public struct App` which collided with `SwiftUI.App`, making it impossible for any SwiftUI app that imports Critic to use `@main struct MyApp: App { ... }` without fully qualifying `SwiftUI.App`. This caused the example app to fail with:

```
CriticExampleApp.swift:6:26: error: 'App' is ambiguous for type lookup in this context
struct CriticExampleApp: App {
                         ^~~
SwiftUI.App -- found this candidate
Critic.App  -- found this candidate
```

Renaming to `CriticApp` resolves the ambiguity for all SwiftUI consumers.

## Test plan

- [ ] Swift package tests pass (`swift test`)
- [ ] Example app compiles without `App` ambiguity error
- [ ] `BugReport.app` property correctly typed as `CriticApp?`

🤖 Generated with [Claude Code](https://claude.com/claude-code)