### PR TITLE
CRITIC-241: Add CHANGELOG, bump to 1.0.0, create release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to release (e.g. v1.0.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -scheme Critic \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            | tail -20
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -scheme Critic \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            | tail -40
+
+  github-release:
+    name: Create GitHub Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Resolve tag name
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog for this version
+        id: notes
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          # Strip leading 'v' to match changelog headings (e.g. v1.0.0 -> 1.0.0)
+          VERSION="${TAG#v}"
+
+          # Extract the section between this version's heading and the next heading
+          NOTES=$(awk \
+            "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" \
+            CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            NOTES="See CHANGELOG.md for details."
+          fi
+
+          # Write to a temp file to handle multi-line output safely
+          echo "$NOTES" > /tmp/release-notes.md
+          echo "notes_file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          gh release create "$TAG" \
+            --title "Critic iOS SDK $TAG" \
+            --notes-file "${{ steps.notes.outputs.notes_file }}" \
+            --verify-tag
+
+  cocoapods-push:
+    name: Push to CocoaPods Trunk
+    needs: github-release
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: Push podspec to trunk
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push Critic.podspec --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Build
         run: |
+          set -o pipefail
           xcodebuild build \
             -scheme Critic \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
@@ -33,6 +34,7 @@ jobs:
 
       - name: Test
         run: |
+          set -o pipefail
           xcodebuild test \
             -scheme Critic \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
@@ -43,9 +45,9 @@ jobs:
     name: Create GitHub Release
     needs: test
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.name }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-
       - name: Resolve tag name
         id: tag
         run: |
@@ -53,6 +55,27 @@ jobs:
             echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
           else
             echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate tag format
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: tag input must match v[0-9]*.[0-9]*.[0-9]* (e.g. v1.0.0). Got: $TAG"
+            exit 1
+          fi
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+
+      - name: Verify tag exists on remote
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          git fetch --tags
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Error: tag $TAG does not exist on the remote. Push the tag before triggering dispatch."
+            exit 1
           fi
 
       - name: Extract changelog for this version
@@ -91,6 +114,8 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ needs.github-release.outputs.tag }}
 
       - name: Install CocoaPods
         run: gem install cocoapods --no-document

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to the Critic iOS SDK are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-30
+
+First stable release. The SDK has been completely rewritten with Swift 6 strict concurrency, async/await, the v3 API, and SwiftUI support.
+
+### Added
+- Swift 6 / async-await rewrite of the entire SDK using native `URLSession` with no external dependencies
+- v3 API client for submitting bug reports and feedback
+- SwiftUI-native feedback view
+- Automatic console log capture via `OSLogStore` attached to bug reports
+- Additional device metadata: extended memory details and network reachability status
+- Swift Package Manager distribution via `Package.swift` (iOS 16+, macOS 13+)
+- Nightly security CI workflow with 7-day package quarantine for CocoaPods dependencies
+- GitHub Actions security audit workflow
+- Comprehensive unit and integration test suite
+- Example app demonstrating SDK integration
+
+### Changed
+- `App` model renamed to `CriticApp` to avoid collision with `SwiftUI.App`
+- Log attachment filename standardized from `console.log` to `console-logs.txt`
+- CI workflow renamed to "Nightly Security" for Scarif integration
+- Network status implementation switched from `DispatchSemaphore` to `SCNetworkReachability`
+- Deployment target raised to iOS 16.0; Swift version set to 6.0
+
+### Removed
+- All GET endpoints removed from the client SDK (submit-only interface)
+- Legacy Objective-C artifacts and dead code from the original SDK
+
+---
+
+## [0.1.5] - 2024-01-01
+
+### Changed
+- Internal maintenance release; version bump only.
+
+## [0.1.4] - 2023-12-01
+
+### Added
+- Support for `device_status` metadata attributes submitted alongside bug reports.
+
+## [0.1.3] - 2023-11-01
+
+### Added
+- Support for `device_status` attributes in bug report submissions.
+
+## [0.1.2] - 2023-10-01
+
+### Changed
+- Minor internal improvements.
+
+## [0.1.1] - 2023-09-01
+
+### Changed
+- Updated to use v2 APIs for bug reporting.
+
+## [0.0.7] - 2023-06-01
+
+### Added
+- Custom product metadata support in the default feedback screen and reporting flow.
+
+## [0.0.6] - 2023-05-01
+
+### Removed
+- Eliminated an unused class.
+
+## [0.0.5] - 2023-04-01
+
+### Changed
+- Updated default feedback screen title.
+
+## [0.0.4] - 2023-03-01
+
+### Changed
+- Updated shake-detection alert style for the "No" (cancel) option.
+- Added informative logging when `Critic.instance().startLogCapture()` is called.
+
+## [0.0.3] - 2023-02-01
+
+### Added
+- Ability to customize default feedback screen and shake-detection dialog text via `Critic.instance()` configuration.
+- Shake detection enabled by default as a trigger to prompt users to submit feedback.
+- Convenience methods to disable log capture and shake detection.
+
+## [0.0.2] - 2023-01-15
+
+### Changed
+- Simplified `reportCreator` by adding a default `init()`.
+
+## [0.0.1] - 2023-01-01
+
+### Added
+- Initial release of the Critic iOS SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,17 @@ First stable release. The SDK has been completely rewritten with Swift 6 strict 
 
 ### Added
 - Initial release of the Critic iOS SDK.
+
+[1.0.0]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.1.5...v1.0.0
+[0.1.5]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.7...v0.1.1
+[0.0.7]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/twinsunllc/inventiv-critic-ios/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/twinsunllc/inventiv-critic-ios/releases/tag/v0.0.1

--- a/Critic.podspec
+++ b/Critic.podspec
@@ -11,7 +11,7 @@ Uses native URLSession and device APIs with no external dependencies.
   s.homepage         = 'https://github.com/twinsunllc/inventiv-critic-ios'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Twin Sun' => 'dev@twinsun.com' }
-  s.source           = { :git => 'https://github.com/twinsunllc/inventiv-critic-ios.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/twinsunllc/inventiv-critic-ios.git', :tag => "v#{s.version}" }
 
   s.ios.deployment_target = '16.0'
   s.swift_version = '6.0'


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — documents all SDK versions from `0.0.1` through `1.0.0`, following the [Keep a Changelog](https://keepachangelog.com) format and grouped by Added/Changed/Removed
- **Version 1.0.0** — `Critic.podspec` already set to `1.0.0`; `Package.swift` has no explicit version constant and is resolved from the git tag, so no change needed there
- **`.github/workflows/release.yml`** — new release workflow triggered on `v*.*.*` tag push or manual dispatch:
  1. Runs `xcodebuild` build + tests on macOS 15 / Xcode 16.2
  2. Creates a GitHub Release with per-version notes extracted from `CHANGELOG.md`
  3. Pushes the podspec to CocoaPods trunk (`COCOAPODS_TRUNK_TOKEN` secret required)
  - SPM distribution requires no additional steps — SPM resolves from the git tag automatically

## Test plan

- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Push a `v1.0.0` tag (or trigger workflow_dispatch) and confirm all three jobs pass: build/test, GitHub Release creation, CocoaPods trunk push
- [ ] Confirm SPM consumers can resolve `1.0.0` from the tag after the release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)