### PR TITLE
fix(package): lower swift-tools-version from 6.1 to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary

- Lowers `swift-tools-version` in `Package.swift` from `6.1` to `6.0`
- Xcode 16.2 (used by both `release.yml` and `ci.yml`) only ships with Swift tools 6.0, causing build failures when encountering the 6.1 declaration
- No Swift 6.1-specific features are used in the package, making this a safe downgrade

## Test plan

- [ ] CI `build-and-test` job passes on Xcode 16.2 matrix entry
- [ ] CI `build-and-test` job passes on Xcode 16.0 matrix entry
- [ ] Release workflow `Build & Test` job passes with Xcode 16.2

Fixes CRITIC-249

🤖 Generated with [Claude Code](https://claude.com/claude-code)