### PR TITLE
fix(ci): restore swift-tools-version 6.1, upgrade to Xcode 16.3, remove CocoaPods push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: "16.2"
+          - xcode: "16.3"
             runner: macos-15
           - xcode: "16.0"
             runner: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
-      - name: Select Xcode 16.2
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Select Xcode 16.3
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Build
         run: |
@@ -108,19 +108,3 @@ jobs:
             --notes-file "${{ steps.notes.outputs.notes_file }}" \
             --verify-tag
 
-  cocoapods-push:
-    name: Push to CocoaPods Trunk
-    needs: github-release
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-        with:
-          ref: ${{ needs.github-release.outputs.tag }}
-
-      - name: Install CocoaPods
-        run: gem install cocoapods --no-document
-
-      - name: Push podspec to trunk
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: pod trunk push Critic.podspec --allow-warnings

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary

- Restores `swift-tools-version: 6.1` in `Package.swift` — the Swift 6.1 downgrade in CRITIC-249 was incorrect; source code uses 6.1 language features
- Updates `release.yml` and `ci.yml` to select Xcode 16.3 instead of 16.2 (required to build Swift 6.1 on `macos-15` runners)
- Removes the `cocoapods-push` job from `release.yml` — CocoaPods trunk is read-only and this step always fails

## Test plan

- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm build and test steps pass with Xcode 16.3
- [ ] Confirm release workflow no longer has a CocoaPods step
- [ ] Confirm Package.swift uses `swift-tools-version: 6.1`

Fixes CRITIC-252

🤖 Generated with [Claude Code](https://claude.com/claude-code)