### PR TITLE
fix(ci): use platform=macOS to avoid missing iOS 18.4 simulator runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
         run: |
           xcodebuild build \
             -scheme Critic \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=macOS' \
             -skipPackagePluginValidation \
             | tail -20
       - name: Test
         run: |
           xcodebuild test \
             -scheme Critic \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=macOS' \
             -skipPackagePluginValidation \
             | tail -40
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           set -o pipefail
           xcodebuild build \
             -scheme Critic \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=macOS' \
             -skipPackagePluginValidation \
             | tail -20
 
@@ -37,7 +37,7 @@ jobs:
           set -o pipefail
           xcodebuild test \
             -scheme Critic \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=macOS' \
             -skipPackagePluginValidation \
             | tail -40
 


### PR DESCRIPTION
## Summary

- Xcode 16.3 on `macos-15` runners does not have the iOS 18.4 simulator runtime pre-installed, causing release and CI builds to fail with `iOS 18.4 is not installed`
- Changed xcodebuild destination from `platform=iOS Simulator,name=iPhone 16,OS=latest` to `platform=macOS` in both `release.yml` and `ci.yml`
- This works because Critic is a pure Swift package with no UIKit/platform-specific dependencies in library or test targets

## Test plan

- [ ] CI `build-and-test` job completes successfully with `platform=macOS` on both Xcode 16.3 and 16.0 matrix entries
- [ ] Release workflow `test` job completes successfully with `platform=macOS`
- [ ] No functional test regressions (same tests run, just on macOS host instead of iOS simulator)

Fixes CRITIC-253

🤖 Generated with [Claude Code](https://claude.com/claude-code)