### PR TITLE
feat: add captureLogsWhenDebugging opt-in flag to iOS SDK (CRITIC-267)

### DIFF
--- a/Example/Sources/CriticExampleApp.swift
+++ b/Example/Sources/CriticExampleApp.swift
@@ -8,7 +8,14 @@ struct CriticExampleApp: App {
         Task {
             do {
                 // Replace with your API token from https://critic.inventiv.io/products
-                try await Critic.shared.initialize(apiToken: "YOUR_API_TOKEN")
+                //
+                // Set captureLogsWhenDebugging: true during development to capture console
+                // logs even when a debugger is attached (e.g. running from Xcode).
+                // Remove or set to false for production builds.
+                try await Critic.shared.initialize(
+                    apiToken: "YOUR_API_TOKEN",
+                    captureLogsWhenDebugging: true
+                )
                 print("Critic SDK initialized successfully")
             } catch {
                 print("Failed to initialize Critic: \(error)")

--- a/Sources/Critic/Critic.swift
+++ b/Sources/Critic/Critic.swift
@@ -33,6 +33,7 @@ import Foundation
 /// - ``appInstallId``
 /// - ``apiToken``
 /// - ``baseURL``
+/// - ``captureLogsWhenDebugging``
 public final class Critic: @unchecked Sendable {
 
     /// The shared singleton instance of the Critic SDK.
@@ -50,6 +51,15 @@ public final class Critic: @unchecked Sendable {
     /// The base URL for the Critic API. Defaults to `https://critic.inventiv.io`.
     public private(set) var baseURL: URL
 
+    /// Whether logs should be captured even when a debugger is attached.
+    ///
+    /// When `true`, ``submitReport(_:attachments:)`` passes the opt-in flag to the log
+    /// capture layer so that console logs are included in bug reports filed from Xcode.
+    /// Defaults to `false` to keep production builds unaffected.
+    ///
+    /// Set this to `true` only in development or testing builds.
+    public private(set) var captureLogsWhenDebugging: Bool = false
+
     private let lock = NSLock()
 
     private init() {
@@ -57,8 +67,8 @@ public final class Critic: @unchecked Sendable {
     }
 
     /// Thread-safe read of mutable properties used by public methods.
-    private func lockedState() -> (api: CriticAPI?, appInstallId: String?) {
-        lock.withLock { (self.api, self.appInstallId) }
+    private func lockedState() -> (api: CriticAPI?, appInstallId: String?, captureLogsWhenDebugging: Bool) {
+        lock.withLock { (self.api, self.appInstallId, self.captureLogsWhenDebugging) }
     }
 
     /// Initialize the SDK with an organization API token.
@@ -69,18 +79,24 @@ public final class Critic: @unchecked Sendable {
     /// - Parameters:
     ///   - apiToken: Your organization's API token from the Critic web portal.
     ///   - baseURL: Optional custom base URL for self-hosted instances. Defaults to `https://critic.inventiv.io`.
+    ///   - captureLogsWhenDebugging: When `true`, console logs are captured and attached to bug
+    ///     reports even when a debugger is attached (e.g. during an Xcode session). Defaults to
+    ///     `false` so production builds are unaffected. Set to `true` only in development or
+    ///     testing builds.
     /// - Throws: ``CriticError`` if the ping request fails.
     #if canImport(UIKit)
     @MainActor
     public func initialize(
         apiToken: String,
-        baseURL: URL? = nil
+        baseURL: URL? = nil,
+        captureLogsWhenDebugging: Bool = false
     ) async throws {
         let resolvedBaseURL = baseURL ?? self.baseURL
 
         lock.withLock {
             self.apiToken = apiToken
             self.baseURL = resolvedBaseURL
+            self.captureLogsWhenDebugging = captureLogsWhenDebugging
             self.api = CriticAPI(baseURL: resolvedBaseURL, apiToken: apiToken)
         }
 
@@ -134,10 +150,10 @@ public final class Critic: @unchecked Sendable {
         _ report: BugReportInput,
         attachments: [(filename: String, mimeType: String, data: Data)]? = nil
     ) async throws -> BugReport {
-        let (api, appInstallId) = lockedState()
+        let (api, appInstallId, captureWhenDebugging) = lockedState()
 
-        guard let api else { throw CriticError.notInitialized }
-        guard let appInstallId else { throw CriticError.notInitialized }
+        guard let api = api else { throw CriticError.notInitialized }
+        guard let appInstallId = appInstallId else { throw CriticError.notInitialized }
 
         #if canImport(UIKit)
         let deviceInfo = DeviceInfo()
@@ -148,7 +164,7 @@ public final class Critic: @unchecked Sendable {
 
         var allAttachments = attachments ?? []
 
-        if let logAttachment = LogCapture.captureRecentLogs() {
+        if let logAttachment = LogCapture.captureRecentLogs(captureWhenDebugging: captureWhenDebugging) {
             allAttachments.append(logAttachment)
         }
 

--- a/Sources/Critic/Utilities/LogCapture.swift
+++ b/Sources/Critic/Utilities/LogCapture.swift
@@ -19,11 +19,15 @@ enum LogCapture {
     /// attachments array.
     ///
     /// Returns `nil` if:
-    /// - A debugger is attached (avoids flooding Xcode console output)
+    /// - A debugger is attached and `captureWhenDebugging` is `false` (avoids flooding Xcode console output)
     /// - The log store cannot be opened
     /// - No entries are found
-    static func captureRecentLogs() -> (filename: String, mimeType: String, data: Data)? {
-        guard !isDebuggerAttached() else { return nil }
+    ///
+    /// - Parameter captureWhenDebugging: When `true`, bypasses the debugger-attached guard so logs
+    ///   are captured even during Xcode debug sessions. Useful for development and testing. Defaults
+    ///   to `false` so that production builds are unaffected.
+    static func captureRecentLogs(captureWhenDebugging: Bool = false) -> (filename: String, mimeType: String, data: Data)? {
+        guard !isDebuggerAttached() || captureWhenDebugging else { return nil }
 
         do {
             let store = try OSLogStore(scope: .currentProcessIdentifier)

--- a/Tests/CriticTests/LogCaptureTests.swift
+++ b/Tests/CriticTests/LogCaptureTests.swift
@@ -32,6 +32,55 @@ import OSLog
     // Either way, the call should not throw or crash.
 }
 
+/// TS-1: captureRecentLogs(captureWhenDebugging: true) bypasses the debugger guard.
+/// When captureWhenDebugging is true, logs should be returned even when a debugger
+/// is attached. The OSLogStore may have permission restrictions in test environments,
+/// so we accept either a valid attachment or nil (store unavailable), but never a crash.
+@Test func logCaptureWithCaptureWhenDebuggingTrueBypassesDebuggerGuard() {
+    // With captureWhenDebugging: true, the debugger-attached guard is skipped.
+    // If OSLogStore is accessible, we get a valid attachment back.
+    // In CI/test runners where the store is restricted, nil is also acceptable.
+    if let attachment = LogCapture.captureRecentLogs(captureWhenDebugging: true) {
+        #expect(attachment.filename == "console-logs.txt")
+        #expect(attachment.mimeType == "text/plain")
+        #expect(!attachment.data.isEmpty)
+    }
+    // The key invariant: this must not crash regardless of debugger state.
+}
+
+/// TS-2: captureRecentLogs() with default false returns nil when debugger is attached.
+/// In the test runner, the debugger is typically attached, so the default call returns nil.
+@Test func logCaptureDefaultReturnNilWhenDebuggerAttached() {
+    // When running under Swift Testing (which attaches a debugger by default),
+    // captureRecentLogs() with the default captureWhenDebugging: false should return nil.
+    // If the test runner is not using a debugger, this test passes trivially.
+    if LogCapture.isDebuggerAttached() {
+        let result = LogCapture.captureRecentLogs()
+        #expect(result == nil)
+    }
+    // When no debugger attached, captureRecentLogs() may return logs — that's correct behavior.
+}
+
+/// TS-3: Critic.shared.captureLogsWhenDebugging defaults to false before initialization.
+@Test func criticCaptureLogsWhenDebuggingDefaultsToFalse() {
+    // Verify that the property type exists and is publicly readable.
+    // On a freshly launched test process, the shared instance is never initialized,
+    // so captureLogsWhenDebugging must be its declared default of false.
+    let critic = Critic.shared
+    // The property declaration initializes to false; submitReport() reads it under lock.
+    // Since no prior test in this file calls initialize(), the value should be false.
+    #expect(critic.captureLogsWhenDebugging == false)
+}
+
+/// TS-4: captureLogsWhenDebugging flag is publicly readable (type-level contract test).
+/// Full end-to-end validation of initialize(captureLogsWhenDebugging:) storing the value
+/// requires UIKit and @MainActor, so this test verifies the API surface compiles correctly.
+@Test func criticCaptureLogsWhenDebuggingPropertyIsReadable() {
+    let value: Bool = Critic.shared.captureLogsWhenDebugging
+    // Property is publicly readable — this test confirms the API surface exists.
+    #expect(value == false || value == true)
+}
+
 @Test func logCaptureEntryTimestampFormat() {
     // Create a known date and verify the formatting.
     // OSLogEntry is not directly constructable, so we test the formatter pattern


### PR DESCRIPTION
## Summary
- Add `captureWhenDebugging: Bool = false` parameter to `LogCapture.captureRecentLogs()` — when `true`, bypasses the `isDebuggerAttached()` guard so logs are captured even in debug sessions
- Add `captureLogsWhenDebugging: Bool = false` property and parameter to `Critic.initialize()`, stored under lock alongside other config state
- Wire the flag through `submitReport()` into `LogCapture.captureRecentLogs()` via updated `lockedState()` return value
- Add DocC documentation on both the property and the `initialize()` parameter explaining the flag should only be `true` in development/testing
- Update example app to demonstrate the opt-in flag with a comment explaining its purpose

## Test plan
- [ ] `captureRecentLogs(captureWhenDebugging: true)` bypasses debugger guard and returns valid attachment (filename=console-logs.txt, mimeType=text/plain) when OSLogStore is accessible
- [ ] `captureRecentLogs()` default (captureWhenDebugging: false) returns nil when debugger is attached
- [ ] `Critic.shared.captureLogsWhenDebugging` defaults to false before initialization
- [ ] `captureLogsWhenDebugging` property is publicly readable (API surface contract)
- [ ] Run example app from Xcode with `captureLogsWhenDebugging: true` and verify submitted bug report includes non-empty console-logs.txt attachment
- [ ] Run example app from Xcode without the flag (default false) and verify no logs are attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)