### PR TITLE
Fix Nightly Security: allowlist GitHub-owned actions in audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowlist: |
             twinsunllc
+            actions
       - name: Upload audit report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: always()


### PR DESCRIPTION
## Summary

The **Nightly Security** workflow ([failing run](https://github.com/twinsunllc/inventiv-critic-ios/actions/runs/27122530727)) fails in the `actions-security` job. `twinsunllc/github-actions-security-checker` flags five first-party GitHub action references as **"Not from verified publisher"**:

- `actions/checkout` (`ci.yml:28`, `ci.yml:55`, `release.yml:21`, `release.yml:68`)
- `actions/upload-artifact` (`ci.yml:63`)

## Root cause

All five references are already pinned to full 40-character commit SHAs and satisfy every rule **except** the verified-publisher dimension. GitHub's own `actions` org does not expose the marketplace "verified publisher" badge that the checker scrapes (the original run also logged transient HTTP 504s fetching those pages). The checker's `allowlist` input exists precisely for this case: trusted namespaces bypass publisher verification while still requiring commit-hash pinning.

## Fix

Add the `actions` namespace to the existing `allowlist` (which previously only listed `twinsunllc`) in the `Run GitHub Actions security audit` step of `.github/workflows/ci.yml`. This makes the official GitHub actions PASS while preserving the hash-pinning requirement.

```diff
           allowlist: |
             twinsunllc
+            actions
```

No action versions/SHAs change; all external references remain SHA-pinned. The `build-and-test` and `release` jobs are untouched.

## Test plan

- [ ] Re-run the **Nightly Security** workflow via `workflow_dispatch` on this branch and confirm the `GitHub Actions Security Check` job exits 0 with all 6 audited actions PASS (`actions/*` shown as "Trusted - bypassing publisher verification").
- [x] Verified every external `uses:` reference in both workflows is pinned to a 40-hex-char commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)